### PR TITLE
move isolation, joust, snailtrail to default build. fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The games currently supported besides chess are listed below. Fairy-Stockfish ca
 - [Clobber](https://en.wikipedia.org/wiki/Clobber)
 - [Cfour](https://en.wikipedia.org/wiki/Connect_Four), [Tic-tac-toe](https://en.wikipedia.org/wiki/Tic-tac-toe)
 - [Flipersi](https://en.wikipedia.org/wiki/Reversi), [Flipello](https://en.wikipedia.org/wiki/Reversi#Othello)
+- [Isolation](https://boardgamegeek.com/boardgame/1875/isolation)
+- [Joust](https://www.chessvariants.com/programs.dir/joust.html)
+- [Snailtrail](https://boardgamegeek.com/boardgame/37135/snailtrail)
+
 
 ## Help
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -109,7 +109,7 @@ namespace Stockfish::Eval::NNUE {
 
   // write_little_endian() is our utility to write an integer (signed or unsigned, any size)
   // to a stream in little-endian order. We swap the byte order before the write if
-  // necessary to always write in little endian order, independantly of the byte
+  // necessary to always write in little endian order, independently of the byte
   // ordering of the compiling machine.
   template <typename IntType>
   inline void write_little_endian(std::ostream& stream, IntType value) {
@@ -137,7 +137,7 @@ namespace Stockfish::Eval::NNUE {
       }
   }
 
-  // read_little_endian(s, out, N) : read integers in bulk from a little indian stream.
+  // read_little_endian(s, out, N) : read integers in bulk from a little endian stream.
   // This reads N integers from stream s and put them in array out.
   template <typename IntType>
   inline void read_little_endian(std::istream& stream, IntType* out, std::size_t count) {
@@ -148,7 +148,7 @@ namespace Stockfish::Eval::NNUE {
               out[i] = read_little_endian<IntType>(stream);
   }
 
-  // write_little_endian(s, values, N) : write integers in bulk to a little indian stream.
+  // write_little_endian(s, values, N) : write integers in bulk to a little endian stream.
   // This takes N integers from array values and writes them on stream s.
   template <typename IntType>
   inline void write_little_endian(std::ostream& stream, const IntType* values, std::size_t count) {

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -181,7 +181,7 @@ namespace {
   // Special multi-leg betza description for Janggi elephant
   PieceInfo* janggi_elephant_piece() {
       PieceInfo* p = from_betza("nZ", "janggiElephant");
-      p->betza = "mafsmafW"; // for compatiblity with XBoard/Winboard
+      p->betza = "mafsmafW"; // for compatibility with XBoard/Winboard
       return p;
   }
 }

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -813,7 +813,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
     // Rs "together" in 62 * 61 / 2 ways (we divide by 2 because rooks can be
     // swapped and still get the same position.)
     //
-    // In case we have at least 3 unique pieces (inlcuded kings) we encode them
+    // In case we have at least 3 unique pieces (included kings) we encode them
     // together.
     if (entry->hasUniquePieces) {
 
@@ -828,7 +828,7 @@ Ret do_probe_table(const Position& pos, T* entry, WDLScore wdl, ProbeState* resu
                    + (squares[1] - adjust1)) * 62
                    +  squares[2] - adjust2;
 
-        // First piece is on a1-h8 diagonal, second below: map this occurence to
+        // First piece is on a1-h8 diagonal, second below: map this occurrence to
         // 6 to differentiate from the above case, rank_of() maps a1-d4 diagonal
         // to 0...3 and finally MapB1H1H7[] maps the b1-h1-h7 triangle to 0..27.
         else if (off_A1H8(squares[1]))
@@ -858,7 +858,7 @@ encode_remaining:
     idx *= d->groupIdx[0];
     Square* groupSq = squares + d->groupLen[0];
 
-    // Encode remainig pawns then pieces according to square, in ascending order
+    // Encode remaining pawns then pieces according to square, in ascending order
     bool remainingPawns = entry->hasPawns && entry->pawnCount[1];
 
     while (d->groupLen[++next])
@@ -886,7 +886,7 @@ encode_remaining:
 
 // Group together pieces that will be encoded together. The general rule is that
 // a group contains pieces of same type and color. The exception is the leading
-// group that, in case of positions withouth pawns, can be formed by 3 different
+// group that, in case of positions without pawns, can be formed by 3 different
 // pieces (default) or by the king pair when there is not a unique piece apart
 // from the kings. When there are pawns, pawns are always first in pieces[].
 //
@@ -918,7 +918,7 @@ void set_groups(T& e, PairsData* d, int order[], File f) {
     //
     // This ensures unique encoding for the whole position. The order of the
     // groups is a per-table parameter and could not follow the canonical leading
-    // pawns/pieces -> remainig pawns -> remaining pieces. In particular the
+    // pawns/pieces -> remaining pawns -> remaining pieces. In particular the
     // first group is at order[0] position and the remaining pawns, when present,
     // are at order[1] position.
     bool pp = e.hasPawns && e.pawnCount[1]; // Pawns on both sides
@@ -938,7 +938,7 @@ void set_groups(T& e, PairsData* d, int order[], File f) {
             d->groupIdx[1] = idx;
             idx *= Binomial[d->groupLen[1]][48 - d->groupLen[0]];
         }
-        else // Remainig pieces
+        else // Remaining pieces
         {
             d->groupIdx[next] = idx;
             idx *= Binomial[d->groupLen[next]][freeSquares];
@@ -948,7 +948,7 @@ void set_groups(T& e, PairsData* d, int order[], File f) {
     d->groupIdx[n] = idx;
 }
 
-// In Recursive Pairing each symbol represents a pair of childern symbols. So
+// In Recursive Pairing each symbol represents a pair of children symbols. So
 // read d->btree[] symbols data and expand each one in his left and right child
 // symbol until reaching the leafs that represent the symbol value.
 uint8_t set_symlen(PairsData* d, Sym s, std::vector<bool>& visited) {

--- a/src/tune.h
+++ b/src/tune.h
@@ -84,7 +84,7 @@ class Tune {
 
   static Tune& instance() { static Tune t; return t; } // Singleton
 
-  // Use polymorphism to accomodate Entry of different types in the same vector
+  // Use polymorphism to accommodate Entry of different types in the same vector
   struct EntryBase {
     virtual ~EntryBase() = default;
     virtual void init_option() = 0;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -481,6 +481,7 @@ namespace {
         v->extinctionPseudoRoyal = true;
         return v;
     }
+
 #ifdef ALLVARS
     // Duck chess
     Variant* duck_variant() {
@@ -494,7 +495,8 @@ namespace {
         v->stalemateValue = VALUE_MATE;
         return v;
     }
-    
+#endif
+
     Variant* isolation_variant() { //https://boardgamegeek.com/boardgame/1875/isolation
         Variant* v = chess_variant_base()->init();
         v->maxRank = RANK_8;
@@ -539,7 +541,7 @@ namespace {
         v->pastGating = true;
         return v;
     }
-#endif
+
     // Three-check chess
     // Check the king three times to win
     // https://lichess.org/variant/threeCheck
@@ -1770,13 +1772,13 @@ void VariantMap::init() {
     add("horde", horde_variant());
     add("nocheckatomic", nocheckatomic_variant());
     add("atomic", atomic_variant());
-#ifdef ALLVARS
     add("isolation", isolation_variant());
     add("isolation7x7", isolation7x7_variant());
     add("snailtrail", snailtrail_variant());
+#ifdef ALLVARS
     add("duck", duck_variant());
-    add("joust", joust_variant());
 #endif
+    add("joust", joust_variant());
     add("3check", threecheck_variant());
     add("5check", fivecheck_variant());
     add("crazyhouse", crazyhouse_variant());
@@ -1879,7 +1881,7 @@ void VariantMap::parse_istream(std::istream& file) {
             if (ss.peek() != ';' && ss.peek() != '#')
             {
                 if (DoCheck && !input.empty() && input.find('=') == std::string::npos)
-                    std::cerr << "Invalid sytax: '" << input << "'." << std::endl;
+                    std::cerr << "Invalid syntax: '" << input << "'." << std::endl;
                 if (std::getline(std::getline(ss, key, '=') >> std::ws, value) && !key.empty())
                     attribs[key.erase(key.find_last_not_of(" ") + 1)] = value;
             }

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -93,7 +93,7 @@
 # You can define custom king movements in the same way you can define another custom piece.
 # E.g., to make the king move like a centaur:
 # king = k:KN
-# In constrast to other custom pieces the Betza notation for the king is optional though
+# In contrast to other custom pieces the Betza notation for the king is optional though
 # and defaults to a standard chess king (betza: K) when skipped, e.g.:
 # king = k
 #
@@ -107,7 +107,7 @@
 # - lame leapers (n) for N, A, Z, and D directions, i.e., nN, nA, nZ, and nD
 
 ### Piece values
-# The predefined and precalculated piece values can be overriden
+# The predefined and precalculated piece values can be overridden
 # by specifying the pieceValueMg and pieceValueEg options, e.g.,
 # pieceValueMg = p:150 n:800
 # pieceValueEg = p:200 n:900

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -86,7 +86,7 @@ ffish['onRuntimeInitialized'] = () => {
 }
 ```
 
-Set a custom fen position including fen validiation:
+Set a custom fen position including fen validation:
 ```javascript
 fen = "rnb1kbnr/ppp1pppp/8/3q4/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3";
 if (ffish.validateFen(fen) == 1) {  // ffish.validateFen(fen) can return different error codes, it returns 1 for FEN_OK

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -574,7 +574,7 @@ describe('board.pushSanMoves(sanMoves, notation)', function () {
 });
 
 describe('board.pocket(turn)', function () {
-  it("it returns the pocket for the given player as a string with no delimeter. All pieces are returned in lower case.", () => {
+  it("it returns the pocket for the given player as a string with no delimiter. All pieces are returned in lower case.", () => {
     let board = new ffish.Board("crazyhouse", "rnb1kbnr/ppp1pppp/8/8/8/5q2/PPPP1PPP/RNBQKB1R/Pnp w KQkq - 0 4");
     chai.expect(board.pocket(WHITE)).to.equal("p");
     chai.expect(board.pocket(BLACK)).to.equal("np");

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -43,7 +43,7 @@ cat << EOF > repeat.exp
  expect eof
 EOF
 
-# to increase the likelyhood of finding a non-reproducible case,
+# to increase the likelihood of finding a non-reproducible case,
 # the allowed number of nodes are varied systematically
 for i in `seq 1 20`
 do


### PR DESCRIPTION
I put isolation, joust, snailtrail under ALLVARS at first to be on the safe side. I haven't seen any problems, so am requesting enabled by default. The most intensive would be Isolation 7x7, which has 360 possible moves at most, which still looks ok.