### PR TITLE
add pre-atomic

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1290,3 +1290,11 @@ pieceToCharTable = P...Q..AH..ECTDY....LKp...q..ah..ectdy....lk
 [atomicduck:atomic]
 duckGating = true
 stalemateValue = win
+
+#https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi/76202?do=show;id=83
+#"pre-atomic" is just an arbitrary name that doesn't start with "atomic"
+#pawns can be caught in the blast in this one
+[pre-atomic:nocheckatomic]
+pawn = -
+customPiece1 = p:fmWfceFifmnD
+pawnTypes = p


### PR DESCRIPTION
"pre-atomic" is an attempt to reproduce early Atomic Chess. In this variant, pawns are susceptible to being caught in the blast radius.