### PR TITLE
add Nuclear

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -360,6 +360,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v->pieceToChar);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v->pieceToChar);
     parse_attribute("petrifyOnCapture", v->petrifyOnCapture);
+    parse_attribute("petrifyBlastPieces", v->petrifyBlastPieces);
     parse_attribute("doubleStep", v->doubleStep);
     parse_attribute("doubleStepRegionWhite", v->doubleStepRegion[WHITE]);
     parse_attribute("doubleStepRegionBlack", v->doubleStepRegion[BLACK]);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2003,7 +2003,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           }
 
           // Make a wall square where the piece was
-          if (var->petrifyOnCapture)
+          if ((var->petrifyOnCapture) && (var->petrifyBlastPieces || bsq==to))
           {
               st->wallSquares |= bsq;
               byTypeBB[ALL_PIECES] |= bsq;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2003,7 +2003,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           }
 
           // Make a wall square where the piece was
-          if ((var->petrifyOnCapture) && (var->petrifyBlastPieces || bsq==to))
+          if (bsq == to ? var->petrifyOnCapture : var->petrifyBlastPieces)
           {
               st->wallSquares |= bsq;
               byTypeBB[ALL_PIECES] |= bsq;

--- a/src/variant.h
+++ b/src/variant.h
@@ -67,6 +67,7 @@ struct Variant {
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
   bool petrifyOnCapture = false;
+  bool petrifyBlastPieces = true;
   bool doubleStep = true;
   Bitboard doubleStepRegion[COLOR_NB] = {Rank2BB, Rank7BB};
   Bitboard tripleStepRegion[COLOR_NB] = {};

--- a/src/variant.h
+++ b/src/variant.h
@@ -67,7 +67,7 @@ struct Variant {
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
   bool petrifyOnCapture = false;
-  bool petrifyBlastPieces = true;
+  bool petrifyBlastPieces = false;
   bool doubleStep = true;
   Bitboard doubleStepRegion[COLOR_NB] = {Rank2BB, Rank7BB};
   Bitboard tripleStepRegion[COLOR_NB] = {};

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1335,7 +1335,7 @@ customPiece1 = i:NN
 customPiece2 = h:mfWcfFfhmnN
 startFen = r8r/3nkqn3/hcb1ii1bch/1hhhhhhhh1/10/10/1HHHHHHHH1/HCB1II1BCH/3NKQN3/R8R
 #technically not needed because of initial setup
-##enPassantRegion = 0
+##enPassantRegion = -
 ##castling = false
 
 #https://boardgamegeek.com/boardgame/32/buffalo-chess
@@ -1593,5 +1593,5 @@ pawn = -
 customPiece1 = p:fmWfceFifmnD
 pawnTypes = p
 petrifyOnCapture = true
-enPassantRegion = 0
+enPassantRegion = -
 petrifyBlastPieces = false

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -169,6 +169,7 @@
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
 # petrifyOnCapture: non-pawn pieces are turned into wall squares when capturing [bool] (default: false)
+# petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: true)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRegionWhite: region where pawn double steps are allowed for white [Bitboard] (default: *2)
 # doubleStepRegionBlack: region where pawn double steps are allowed for black [Bitboard] (default: *2)
@@ -1582,3 +1583,15 @@ customPiece4 = w:mRpRFAcpR
 customPiece5 = f:mBpBWDcpB
 promotedPieceType = u:w a:w c:f i:f
 startFen = lnsgkgsnl/1rci1uab1/p1p1p1p1p/9/9/9/P1P1P1P1P/1BAU1ICR1/LNSGKGSNL[-] w 0 1
+
+#https://www.chessvariants.com/difftaking.dir/deadsquare.html
+[nuclear:atomic]
+#define a piece that looks exactly like a pawn, but is not one. Takes care of major differences:
+#1. Pawns can be petrified.
+#2. Pawns can be destroyed by explosions.
+pawn = -
+customPiece1 = p:fmWfceFifmnD
+pawnTypes = p
+petrifyOnCapture = true
+enPassantRegion = 0
+petrifyBlastPieces = false

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -169,7 +169,7 @@
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
 # petrifyOnCapture: non-pawn pieces are turned into wall squares when capturing [bool] (default: false)
-# petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: true)
+# petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRegionWhite: region where pawn double steps are allowed for white [Bitboard] (default: *2)
 # doubleStepRegionBlack: region where pawn double steps are allowed for black [Bitboard] (default: *2)
@@ -1594,4 +1594,3 @@ customPiece1 = p:fmWfceFifmnD
 pawnTypes = p
 petrifyOnCapture = true
 enPassantRegion = -
-petrifyBlastPieces = false


### PR DESCRIPTION
The interaction between Blast and Petrify:

If no special effort, then each piece in the blast will be petrified. This differs from Nuclear rules, where only ground zero is petrified. So petrifyBlastPieces was made to toggle this. It is set to true by default, in case anyone was depending on the previous behaviour.