### PR TITLE
Add Gethenian variant to INI file

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1727,3 +1727,33 @@ castlingWins = q
 
 [opposite-castling:chess]
 oppositeCastling = true
+
+# A Kyoto Shogi variant with a left/right theme.
+[gethenian]
+maxRank = 7
+maxFile = 7
+king = -
+customPiece1 = k:K
+customPiece2 = q:mW
+customPiece3 = b:lfrbB
+customPiece4 = i:rflbB
+customPiece5 = r:lrR
+customPiece6 = n:hlN
+customPiece7 = t:hrN
+customPiece8 = m:WfF
+customPiece9 = s:FfW
+startFen = 2ikb2/2mnm2/7/7/7/2MNM2/2B+KI2[] w - - 0 1
+promotionPieceTypes = -
+promotedPieceType = k:q b:r i:r n:t m:s
+promotionRegionWhite = *1 *2 *3 *4 *5 *6 *7
+promotionRegionBlack = *7 *6 *5 *4 *3 *2 *1
+mandatoryPiecePromotion = true
+pieceDemotion = true
+pieceDrops = true
+capturesToHand = true
+dropPromoted = true
+immobilityIllegal = false
+extinctionValue = loss
+extinctionPieceTypes = kq
+extinctionPseudoRoyal = true
+stalemateValue = loss


### PR DESCRIPTION
Hi, I've added a custom variant of my own design to the default configuration INI file and would be delighted if it could be included with the default distribution of Fairy-Stockfish.

I have done quite a bit of testing so far, so don't expect to need to revise the rules in the near future (i.e., fairy bit of play-testing, starting position balanced with NN and MCTS).

Clear skies,
Brian