### PR TITLE
Bump version (0.7.5)

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "types": "ffish.d.ts",


### PR DESCRIPTION
Release files are available at:
https://www.npmjs.com/package/ffish-es6