### PR TITLE
improve connection games

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1283,6 +1283,15 @@ namespace {
     // Connect-n
     if (pos.connect_n() > 0)
     {
+        //Calculate eligible pieces for connection once.
+        //Still consider all opponent pieces as blocking.
+        Bitboard connectPiecesUs = 0;
+        for (PieceSet ps = pos.connect_piece_types(); ps;){
+            PieceType pt = pop_lsb(ps);
+            connectPiecesUs |= pos.pieces(pt);
+        };
+        connectPiecesUs &= pos.pieces(Us);
+
         for (const Direction& d : pos.getConnectDirections())
 
         {
@@ -1296,9 +1305,10 @@ namespace {
                 Square s = pop_lsb(b);
                 int c = 0;
                 for (int j = 0; j < pos.connect_n(); j++)
-                    if (pos.pieces(Us) & (s - j * d))
+                    if (connectPiecesUs & (s - j * d))
                         c++;
-                score += make_score(200, 200)  * c / (pos.connect_n() - c) / (pos.connect_n() - c);
+                score += (pos.variant()->connectValue==VALUE_MATE ? 1 : -1) * //At least change the sign for misere variants.
+                             (make_score(200, 200)  * c / (pos.connect_n() - c) / (pos.connect_n() - c));
             }
         }
     }

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1541,13 +1541,21 @@ startFen = wWwWw/WwWwW/wW1Ww/WwWwW/wWwWw w
 stalemateValue = loss
 nMoveRule = 0
 
-[picaria:tictactoe]
+[picaria]
 #Known under multiple names but using the name from Wikipedia.
 #https://ludii.games/details.php?keyword=Picaria https://en.wikipedia.org/wiki/Picaria
 #https://ludii.games/details.php?keyword=Les%20Pendus
 #https://ludii.games/details.php?keyword=Wure%20Dune
 #https://ludii.games/details.php?keyword=Djara-Badakh
 #https://ludii.games/details.php?keyword=Tuk%20Tak
+maxRank = 3
+maxFile = 3
+pieceDrops = true
+doubleStep = false
+castling = false
+stalemateValue = draw
+immobilityIllegal = false
+connectN = 3
 customPiece1 = p:mKmNmAmD
 #moves anywhere on the board, KNAD is a list of all possible moves on a 3x3
 startFen = 3/3/3[PPPppp] w - - 0 1
@@ -1895,7 +1903,12 @@ doubleStepRegionWhite = *3
 doubleStepRegionBlack = *8
 
 #https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1723
-[symphony:tictactoe]
+[symphony]
+pieceDrops = true
+doubleStep = false
+castling = false
+stalemateValue = draw
+immobilityIllegal = false
 maxRank = 8
 maxFile = 8
 connectN = 5


### PR DESCRIPTION
1. Change evaluate.cpp to also take into account connectPieceTypes when evaluating how close to connectN
2. Change evaluate.cpp to also take into account connectValue. There's not many misere variants to go on, but reversing the sign is a start.
3. Expand symphony and picaria to not inherit from tictactoe. There was an empty connectPieceTypes when inheriting from tictactoe.