### PR TITLE
Fix stack overflow when depth is too deep

### DIFF
--- a/src/movegen.h
+++ b/src/movegen.h
@@ -55,12 +55,37 @@ inline bool operator<(const ExtMove& f, const ExtMove& s) {
 template<GenType>
 ExtMove* generate(const Position& pos, ExtMove* moveList);
 
+constexpr size_t moveListSize = sizeof(ExtMove) * MAX_MOVES;
+
 /// The MoveList struct is a simple wrapper around generate(). It sometimes comes
 /// in handy to use this class instead of the low level generate() function.
 template<GenType T>
 struct MoveList {
 
-  explicit MoveList(const Position& pos) : last(generate<T>(pos, moveList)) {}
+  
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+    explicit MoveList(const Position& pos)
+    {
+        this->moveList = (ExtMove*)malloc(moveListSize);
+        if (this->moveList == 0)
+        {
+            printf("Error: Failed to allocate memory in heap. Size: %llu\n", moveListSize);
+            exit(1);
+        }
+        this->last = generate<T>(pos, this->moveList);
+    }
+
+    ~MoveList()
+    {
+        free(this->moveList);
+    }
+#else
+    explicit MoveList(const Position& pos) : last(generate<T>(pos, moveList))
+    {
+        ;
+    }
+#endif
+  
   const ExtMove* begin() const { return moveList; }
   const ExtMove* end() const { return last; }
   size_t size() const { return last - moveList; }
@@ -69,7 +94,12 @@ struct MoveList {
   }
 
 private:
-  ExtMove moveList[MAX_MOVES], *last;
+    ExtMove* last;
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+    ExtMove* moveList = 0;
+#else
+    ExtMove moveList[MAX_MOVES];
+#endif
 };
 
 } // namespace Stockfish

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -69,7 +69,7 @@ struct MoveList {
         this->moveList = (ExtMove*)malloc(moveListSize);
         if (this->moveList == 0)
         {
-            printf("Error: Failed to allocate memory in heap. Size: %llu\n", moveListSize);
+            printf("Error: Failed to allocate memory in heap.");
             exit(1);
         }
         this->last = generate<T>(pos, this->moveList);

--- a/src/types.h
+++ b/src/types.h
@@ -233,14 +233,23 @@ constexpr int SQUARE_BITS = 6;
 #ifdef ALLVARS
 constexpr int MAX_MOVES = 8192;
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-constexpr int MAX_PLY = 246;
+//Since it's unlikely to run out of heap, the max depth can be set much deeper.
+constexpr int MAX_PLY = 1024;
 #else
 constexpr int MAX_PLY = 60;
 #endif
+/// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #else
 constexpr int MAX_MOVES = 1024;
-constexpr int MAX_PLY   = 246;
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+//Since it's unlikely to run out of heap, the max depth can be set much deeper.
+constexpr int MAX_PLY = 1024;
+#else
+constexpr int MAX_PLY = 246;
 #endif
+/// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+#endif
+/// endif ALLVARS
 
 /// A move needs 16 bits to be stored
 ///

--- a/src/types.h
+++ b/src/types.h
@@ -227,9 +227,16 @@ typedef uint64_t Bitboard;
 constexpr int SQUARE_BITS = 6;
 #endif
 
+//When defined, move list will be stored in heap. Delete this if you want to use stack to store move list. Using stack can cause overflow (Segmentation Fault) when the search is too deep.
+#define USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+
 #ifdef ALLVARS
 constexpr int MAX_MOVES = 8192;
-constexpr int MAX_PLY   = 60;
+#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
+constexpr int MAX_PLY = 246;
+#else
+constexpr int MAX_PLY = 60;
+#endif
 #else
 constexpr int MAX_MOVES = 1024;
 constexpr int MAX_PLY   = 246;

--- a/src/types.h
+++ b/src/types.h
@@ -233,8 +233,7 @@ constexpr int SQUARE_BITS = 6;
 #ifdef ALLVARS
 constexpr int MAX_MOVES = 8192;
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-//Since it's unlikely to run out of heap, the max depth can be set much deeper.
-constexpr int MAX_PLY = 1024;
+constexpr int MAX_PLY = 246;
 #else
 constexpr int MAX_PLY = 60;
 #endif
@@ -242,7 +241,6 @@ constexpr int MAX_PLY = 60;
 #else
 constexpr int MAX_MOVES = 1024;
 constexpr int MAX_PLY = 246;
-/// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #endif
 /// endif ALLVARS
 

--- a/src/types.h
+++ b/src/types.h
@@ -241,12 +241,7 @@ constexpr int MAX_PLY = 60;
 /// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #else
 constexpr int MAX_MOVES = 1024;
-#ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
-//Since it's unlikely to run out of heap, the max depth can be set much deeper.
-constexpr int MAX_PLY = 1024;
-#else
 constexpr int MAX_PLY = 246;
-#endif
 /// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #endif
 /// endif ALLVARS


### PR DESCRIPTION
#583 .

After this change, added a macro definition that can switch the preference whether to put the move list in stack or in heap. Now given the following commands:
```
uci
setoption name UCI_Variant value gustav3
position fen arnbqkbnra/*ppp1pppp*/*3p4*/*8*/*8*/*N1P5*/*PP1PPPPP*/AR1BQKBNRA b KQkq - 0 2 moves f7f5 f2f3 d8e7 e2e4 i7i5 i2i4 j8g5 c2c3 c8d6 a1c2 h8g6 c2d2 f5f4 h1f2 e6e5 j1g4 b7b6 g4g5 e7g5 f2g4 a8b7 d2f2 d6f7 d3d4 d7d6 b3d2 b7d8 d1b3 c7c5 e1e2 g5h4 g2g3 h4e7 f2h3 f7g5 h3h5 g8b3 d2b3 d8f7 b3d2 b6b5 b1d1 g6h8 h5f7 h8f7 f1g2 c5d4 c3d4 b8c8 g1f2 f7h6 d4e5 h6g4 f3g4 d6e5 d2f3 f8h8 f3g5 e7g5 g3f4 g5f4 d1d6 h7h6 d6d5 c8c4 b2b3 c4c3 d5d3 c3d3 e2d3 e8c8 g2h3 g8d8 d3b5 c8c2 f2g3 d8d3 i1g1 d3b3 b5f1 c2e4 f1d1 b3d3 d1b1 h8i7 g1d1 f4d2 b1b2 e4e2 b2b7 i7h7 d1g1 e5e4 g1g2 e2f3 b7b5 d2g5 b5f5 f3f5 g4f5 e4e3 g2b2 d3d4 b2b6 d4e4 b6e6 e4e6 f5e6 h7g6 h3g4 g6f6 g4f3 f6e6 g3c7 g7g6 h2h3 h6h5 c7g3 h5i4 h3i4 g5h6 f3e4 e6f6 g3e5 f6f7 e5g3 f7f6 g3e5 f6f7 e5g3 f7e6 g3e1 e6d6 e1b4 d6e6 b4e1 e6f6 e1g3 e3e2 e4f3 f6g5 g3f2 h6g7 f2g3 g7h6 g3f2 g5f5 f2g3 h6f8 g3f2 f8g7 f2e1 g6g5 e1g3 g7f8 g3e1 g5g4 f3e2 f5f4 e2f2 f8e7 e1d2 f4f5 d2h6 e7h4 f2g2 f5g6 h6e3 g4g3 e3d2 g6f5 g2f3 g3g2 f3g2 f5g4 d2h6 h4e1 h6i5 e1i5 g2f1 i5h4 i4i5 h4i5 f1g2 i5e1 g2f1 e1d2 f1g2 d2c1 g2f1 c1b2 f1e1 b2a1 e1d1 a1b2 d1e2 b2a1 e2d1 a1b2 d1e2 g4g5 e2f1 b2a1 f1e1 a1b2 e1e2 b2a1 e2d1 a1b2 d1e2 b2a1 e2d1 g5h5 d1c1 a1b2 c1b1 b2a1 b1a1 h5g4 a1b1 g4f3 b1a1 f3e2 a1b1 e2d1 b1a1
go
```

It will work correctly to depth 245.

The build is successful without warnings on my PC, running MSYS2 MinGW64.

I've also did some bench test on the 2 methods on the same computer with the same environment. Interestingly, the heap method is slightly faster than the stack method. The test command is:
```
uci
bench
bench
bench
bench
bench
```

Result:
![image](https://github.com/fairy-stockfish/Fairy-Stockfish/assets/47345902/1aa0c06a-cbcc-4ef9-b552-b284dc323b6d)
