### PR TITLE
Drop Region Per Piece Type

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -334,6 +334,12 @@ LDFLAGS += $(EXTRALDFLAGS)
 # Ignore warning due to missing profile information from unused NNUE features
 CXXFLAGS += -Wno-profile-instr-out-of-date
 
+# Ingnore warning due to implicit declaration of operator= in Stockfish::Variant(const Stockfish::Variant&)
+# Because the = is intended to copy all data from another Variant structure without having to write the assignment code manually one by one which creates much overhead
+# The reason why it is necessary to define Stockfish::Variant(const Stockfish::Variant&) is that it contains memory segments in heap which requires re-allocation when creating a new one
+# Otherwise you will encounter segmentation fault
+CXXFLAGS += -Wno-deprecated-copy
+
 # Compile version with support for large board variants
 # Use precomputed magics by default if pext is not available
 ifneq ($(largeboards),no)

--- a/src/position.h
+++ b/src/position.h
@@ -664,6 +664,22 @@ inline Bitboard Position::drop_region(Color c) const {
 inline Bitboard Position::drop_region(Color c, PieceType pt) const {
   Bitboard b = drop_region(c) & board_bb(c, pt);
 
+  // Piece specific drop region
+  // Only filter moves based on drop_region() which is a restriction that applies to all pieces
+  // Set whiteDropRegion/blackDropRegion to AllSquares to remove the restriction
+  if (var->pieceSpecificDropRegion)
+  {
+      assert(var->whitePieceDropRegion != 0 && var->blackPieceDropRegion != 0);
+      if (c == WHITE)
+      {
+          b &= var->whitePieceDropRegion->boardOfPiece(toupper(piece_to_char()[(c << PIECE_TYPE_BITS) + pt]));
+      }
+      else if (c == BLACK)
+      {
+          b &= var->blackPieceDropRegion->boardOfPiece(toupper(piece_to_char()[(c << PIECE_TYPE_BITS) + pt]));
+      }
+  }
+
   // Pawns on back ranks
   if (pt == PAWN)
   {

--- a/src/types.h
+++ b/src/types.h
@@ -227,6 +227,76 @@ typedef uint64_t Bitboard;
 constexpr int SQUARE_BITS = 6;
 #endif
 
+//The piece type count. Currently we have A-Z as piece type so it's 26.
+constexpr size_t PIECE_TYPE_COUNT = 26;
+
+//This is a bitboard group that matches to all 26 piece types.
+//Each bitboard is related to a piece type, so we have PIECE_TYPE_COUNT of bitboards.
+//For example, piece A is related to boardlist[0], piece B is related to boardlist[1], etc.
+struct PieceTypeBitboardGroup
+{
+    PieceTypeBitboardGroup()
+    {
+        size_t i;
+        this->boardlist = (Bitboard*)malloc(PIECE_TYPE_COUNT * sizeof(Bitboard));
+        // By default, all squares are allowed for all pieces.
+        for (i = 0; i < PIECE_TYPE_COUNT; i++)
+        {
+            this->boardlist[i] ^= ~this->boardlist[i];
+        }
+    }
+
+    PieceTypeBitboardGroup(const PieceTypeBitboardGroup& other)
+    {
+        size_t i;
+        this->boardlist = (Bitboard*)malloc(PIECE_TYPE_COUNT * sizeof(Bitboard));
+        for (i = 0; i < PIECE_TYPE_COUNT; i++)
+        {
+            this->boardlist[i] = other.boardlist[i];
+        }
+    }
+
+    ~PieceTypeBitboardGroup()
+    {
+        free(this->boardlist);
+    }
+
+    // Returns the bitboard reference at the index of idx in boardlist.
+    // idx: The index
+    // <return value>: Bitboard reference at index <idx> in boardlist
+    Bitboard& at(const size_t idx)
+    {
+        assert(idx >= 0 && idx < PIECE_TYPE_COUNT);
+        return this->boardlist[idx];
+    }
+
+    // Returns the bitboard copy of a piece type.
+    // ptc: Only accepts A-Z
+    // <return value>: The copy of corresponding bitboard
+    // Example:
+    // _begin
+    // PieceTypeBitboardGroup a;
+    // Bitboard boardOfPieceA = a.boardOfPiece('A');
+    // _end
+    Bitboard boardOfPiece(const char ptc)
+    {
+        assert(ptc >= 65 && ptc <= 90);  //ASCII of 'A'=65
+        return this->boardlist[ptc - 65];
+    }
+
+    // Set the bitboard of a piece type.
+    // ptc: Only accepts A-Z
+    // board: The bitboard to set
+    void set(const char ptc, Bitboard board)
+    {
+        assert(ptc >= 65 && ptc <= 90);  //ASCII of 'A'=65
+        *(this->boardlist + (ptc - 65)) = board;
+    }
+
+private:
+    Bitboard* boardlist = 0;
+};
+
 //When defined, move list will be stored in heap. Delete this if you want to use stack to store move list. Using stack can cause overflow (Segmentation Fault) when the search is too deep.
 #define USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 

--- a/src/variant.h
+++ b/src/variant.h
@@ -99,6 +99,9 @@ struct Variant {
   Bitboard enclosingDropStart = 0;
   Bitboard whiteDropRegion = AllSquares;
   Bitboard blackDropRegion = AllSquares;
+  bool pieceSpecificDropRegion = false;
+  PieceTypeBitboardGroup* whitePieceDropRegion = 0;
+  PieceTypeBitboardGroup* blackPieceDropRegion = 0;
   bool sittuyinRookDrop = false;
   bool dropOppositeColoredBishop = false;
   bool dropPromoted = false;
@@ -178,6 +181,26 @@ struct Variant {
   bool endgameEval = false;
   bool shogiStylePromotions = false;
   std::vector<Direction> connect_directions;
+
+  Variant()
+  {
+      // Avoid using stack
+      this->whitePieceDropRegion = new PieceTypeBitboardGroup();
+      this->blackPieceDropRegion = new PieceTypeBitboardGroup();
+  }
+
+  Variant(const Variant& other)
+  {
+      (*this) = other;
+      this->whitePieceDropRegion = new PieceTypeBitboardGroup(*(other.whitePieceDropRegion));
+      this->blackPieceDropRegion = new PieceTypeBitboardGroup(*(other.blackPieceDropRegion));
+  }
+
+  ~Variant()
+  {
+      delete this->whitePieceDropRegion;
+      delete this->blackPieceDropRegion;
+  }
 
   void add_piece(PieceType pt, char c, std::string betza = "", char c2 = ' ') {
       // Avoid ambiguous definition by removing existing piece with same letter

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -126,6 +126,7 @@
 # [PieceSet]: multiple piece types [letters defined for pieces, e.g., nbrq]
 # [CastlingRights]: set of castling rights [letters for castling rights as in FEN, e.g., KQkq]
 # [Bitboard]: list of squares [e.g., d4 e4 d5 e5]. * can be used as wildcard for files (e.g., *1 is the first rank)
+# [PieceTypeBitboardGroup]: list of squares for different pieces. * can be used as wildcard for files and ranks (e.g., *1 is the first rank, ** means everywhere, a* means file a). The syntax is [<piece char (in upper case)>(<location[, ...]>); [...]]. Pieces not specified are equivalent to "<not specified piece char>(**);". Example: P(e4,*1);Q(a1,a2,b*);K(**);
 # [Value]: game result for the side to move [win, loss, draw]
 # [MaterialCounting]: material counting rules for adjudication [janggi, unweighted, whitedrawodds, blackdrawodds, none]
 # [CountingRule]: makruk, cambodian, or ASEAN counting rules [makruk, cambodian, asean, none]
@@ -222,6 +223,9 @@
 # enclosingDropStart: drop region for starting phase disregarding enclosingDrop (e.g., for reversi) [Bitboard]
 # whiteDropRegion: restrict region for piece drops of all white pieces [Bitboard]
 # blackDropRegion: restrict region for piece drops of all black pieces [Bitboard]
+# pieceSpecificDropRegion: whether to enable drop region per piece type restriction [bool]
+# whitePieceDropRegion: the drop region of each piece for white which is under whiteDropRegion restriction [PieceTypeBitboardGroup]
+# blackPieceDropRegion: the drop region of each piece for black which is under blackDropRegion restriction [PieceTypeBitboardGroup]
 # sittuyinRookDrop: restrict region of rook drops to first rank [bool] (default: false)
 # dropOppositeColoredBishop: dropped bishops have to be on opposite-colored squares [bool] (default: false)
 # dropPromoted: pieces may be dropped in promoted state [bool] (default: false)


### PR DESCRIPTION
After this change, I added a structure `PieceTypeBitboardGroup` consisting of 26 bitboards as a vector to store the corresponding bitboards of each piece type (from A to Z, which is 26). It also supports parsing from variants.ini.

The following options are added:
**bool** pieceSpecificDropRegion - When true, enable "Drop Region Per Piece Type" feature, and piece specific drop regions are applied based on dropRegionWhite / dropRegionBlack (i.e. It only filters moves that not allowed in piece specific drop regions based on dropRegionWhite / dropRegionBlack and does not add a drop that is allowed in  piece specific drop regions as a new drop if the drop is banned in dropRegionWhite / dropRegionBlack). When false, does nothing. _**Existing variants are not affected.**_
**PieceTypeBitboardGroup** whitePieceDropRegion - The region of different pieces that can drop for white.
**PieceTypeBitboardGroup** blackPieceDropRegion - The region of different pieces that can drop for black.

I've tested in ffish.cpp and it works as intended. The test variant file is:
```
[test001:crazyhouse]
pieceSpecificDropRegion = true
whitePieceDropRegion = P(e*);Q(*1);R(**);N(e3,d3);
blackPieceDropRegion = P(d*);Q(*8);R(**);N(e6,d6);
```