### PR TITLE
Add missing rules for minihouse variant

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -575,6 +575,9 @@ promotionPawnTypes = -
 maxRank = 6
 maxFile = 6
 startFen = 2bnrk/5p/6/6/P5/KRNB2
+promotionPieceTypes = nbr
+promotionRegionWhite = *6
+doubleStep = f
 
 #https://www.chess.com/variants/rookmate
 [rookmate:chess]


### PR DESCRIPTION
missing rules added: 
1. Only promote to Rook, Knight, Bishop.
2. White to promote at 6th rank.
3. No double step.