### PR TITLE
Small contribution on a compatible anti/giveaway variant

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1970,3 +1970,13 @@ flagPiece = k
 flagRegionWhite = *8
 flagRegionBlack = *1
 startFen = lhatkahl/ssssssss/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1
+
+#https://www.chessvariants.com/diffobjective.dir/giveaway.html
+#When stalemate, the stalemated player does not move but the opponent can if he wish to play for win go on moving and do as many moves he wants to do. 
+#If the stalemate then disappear, both players move again as usual. So, if white for example has a pawn on h2 and nothing more and black a pawn on h3, pawn on a7 and rooks on a8 and h8 
+# black can win by moving : 1.-,Rh4 2.-, a5. 3.-, a4 4.- Ra5 5.-,a3 6.-,a2 7.-,a1=R 8.-,Rg1 9.-,Rg3 10.hxg3,h2 11.gxh4,Rg5 12.hxg5,h1=Q 13.g6,Qh7 14.gxh7 and black has won.
+[andersgiveaway:giveaway]
+passOnStalemate = true
+
+[andersanti:antichess]
+passOnStalemate = true


### PR DESCRIPTION
As described here

https://www.chessvariants.com/diffobjective.dir/giveaway.html

> "More interesting seems Anders Ebenfelt's variant:
> 
>     When stalemate, the stalemated player does not move but the opponent can if he wish to play for win go on moving and do as many moves he wants to do. If the stalemate then disappear, both players move again as usual. So, if white for example has a pawn on h2 and nothing more and black a pawn on h3, pawn on a7 and rooks on a8 and h8 black can win by moving : 1.-,Rh4 2.-, a5. 3.-, a4 4.- Ra5 5.-,a3 6.-,a2 7.-,a1=R 8.-,Rg1 9.-,Rg3 10.hxg3,h2 11.gxh4,Rg5 12.hxg5,h1=Q 13.g6,Qh7 14.gxh7 and black has won.
> 
>     This variant has the advantage that there is often dangerous to let the opponent take all pieces but one if the one left is a pawn which can be blocked. The game will then be more complicated, or sophisticated (the strategy is not only to throw away pieces)."

Works well with the variants.ini configuration, and it seems like an interesting anti-variant, without a name, but added his first name to both variants.

Just a small contribution, that seems interesting.

Big props from a fan of the project.