### PR TITLE
Do more full window searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1368,10 +1368,9 @@ moves_loop: // When in check, search starts from here
           }
       }
 
-      // For PV nodes only, do a full PV search on the first move or after a fail
-      // high (in the latter case search only if value < beta), otherwise let the
-      // parent node fail low with value <= alpha and try another move.
-      if (PvNode && (moveCount == 1 || (value > alpha && (rootNode || value < beta))))
+      // For PV nodes only, do a full PV search on the first move or after a fail high,
+      // otherwise let the parent node fail low with value <= alpha and try another move.
+      if (PvNode && (moveCount == 1 || value > alpha))
       {
           (ss+1)->pv = pv;
           (ss+1)->pv[0] = MOVE_NONE;


### PR DESCRIPTION
Remove the `value < beta` condition for doing full window searches. 
As an added bonus the condition for full-window search is now much more similar to other fail-soft engines.