### PR TITLE
Add sudoku chess variant

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -488,6 +488,11 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("flyingGeneral", v->flyingGeneral);
     parse_attribute("soldierPromotionRank", v->soldierPromotionRank);
     parse_attribute("flipEnclosedPieces", v->flipEnclosedPieces);
+    parse_attribute("sudoku", v->sudoku);
+    parse_attribute("sudokuBoxWidth", v->sudokuBoxWidth);
+    parse_attribute("sudokuBoxHeight", v->sudokuBoxHeight);
+    parse_attribute("sudokuAllowedPawns", v->sudokuAllowedPawns);
+    parse_attribute("sudokuRoyalConflict", v->sudokuRoyalConflict);
     // game end
     parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[WHITE], v->pieceToChar);
     parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[BLACK], v->pieceToChar);
@@ -639,6 +644,24 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
         }
         if (v->flagPieceSafe && v->blastOnCapture)
             std::cerr << "Can not use flagPieceSafe with blastOnCapture (flagPieceSafe uses simple assessment that does not see blast)." << std::endl;
+    }
+    // Check invalid sudoku box sizes
+    if (v->sudoku && v->sudokuBoxWidth && v->sudokuBoxHeight)
+    {
+        int boxesCount = (v->maxFile / v->sudokuBoxWidth + 1) * (v->maxRank / v->sudokuBoxHeight + 1);
+        if (DoCheck)
+        {
+            int width = v->maxFile + 1, height = v->maxRank + 1;
+            if (width % v->sudokuBoxWidth || height % v->sudokuBoxHeight)
+                std::cerr << "Sudoku boxes don't fit the board size" << std::endl;
+            if (boxesCount > width && boxesCount > height)
+                std::cerr << "Too many sudoku boxes" << std::endl;
+        }
+        // Ensure that boxes' count doesn't exceed the allocated array size for tracking the conflicts
+        // (see StateInfo::pieceCountInSudokuHouse).
+        // Do this safety measure even when DoCheck is false to avoid memory access issues.
+        if (boxesCount > FILE_NB)
+            v->sudokuBoxWidth = v->sudokuBoxHeight = 0;
     }
     return v;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -587,6 +587,13 @@ struct DirtyPiece {
 /// avoid left-shifting a signed int to avoid undefined behavior.
 enum Score : int { SCORE_ZERO };
 
+enum SudokuHouse : int {
+  SH_FILE,
+  SH_RANK,
+  SH_BOX,
+  SH_NB,
+};
+
 constexpr Score make_score(int mg, int eg) {
   return Score((int)((unsigned int)eg << 16) + mg);
 }

--- a/src/variant.h
+++ b/src/variant.h
@@ -119,6 +119,11 @@ struct Variant {
   Rank soldierPromotionRank = RANK_1;
   EnclosingRule flipEnclosedPieces = NO_ENCLOSING;
   bool freeDrops = false;
+  bool sudoku = false;
+  int sudokuBoxWidth = 4;
+  int sudokuBoxHeight = 2;
+  int sudokuAllowedPawns = FILE_NB;
+  bool sudokuRoyalConflict = false;
 
   // game end
   PieceSet nMoveRuleTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -296,6 +296,11 @@
 # adjudicateFullBoard: apply material counting immediately when board is full [bool] (default: false)
 # countingRule: enable counting rules [CountingRule] (default: none)
 # castlingWins: Specified castling moves are win conditions. Losing these rights is losing. [CastlingRights] (default: -)
+# sudoku: enable sudoku variant - can't capture opponent's pieces when having sudoku conflicts on your pieces [bool] (default: false)
+# sudokuBoxWidth: the width of sudoku box (0 to disable boxes) [int] (default: 4)
+# sudokuBoxHeight: the height of sudoku box (0 to disable boxes) [int] (default: 2)
+# sudokuAllowedPawns: how many pawns could be in a sudoku house without having a sudoku conflict [int] (default: unlimited)
+# sudokuRoyalConflict: treat queen and king (or commoner) as one piece type for sudoku conflicts [bool] (default: false)
 
 ################################################
 ### Example for minishogi configuration that would be equivalent to the built-in variant:
@@ -2010,3 +2015,17 @@ passOnStalemate = true
 
 [andersanti:antichess]
 passOnStalemate = true
+
+[sudoku:chess]
+king = -
+commoner = k
+castlingKingPiece = k
+extinctionValue = loss
+extinctionPieceTypes = k
+sudoku = true
+
+[sudokupawns:sudoku]
+sudokuAllowedPawns = 2
+
+[sudokuroyal:sudokupawns]
+sudokuRoyalConflict = true


### PR DESCRIPTION
The PR introduces a new chess variant - "sudoku chess".
In a few words, it's normal chess, but player is not allowed to capture opponent's pieces while player's pieces break 8x8 sudoku rules (i.e. there are repeating pieces of the same type in a file, rank or 4x2 box). Full rules reference: https://gist.github.com/yusitnikov/e81a5e4df2fce6a854db8a2950fa5cfc

Benchmark results:
- "Nodes searched" value didn't change comparing to the official version (checked with NNUE enabled and disabled).
- Total time is around 2-3% slower than the official version, and the reason for it is allocating more memory in the `StateInfo` struct. I guess that it could be solved by allocating the memory dynamically only when the variant is enabled, but it will add complexity to the codebase. Is it worth optimizations?

Compatibility:
I personally plan using the variant only with classic setup: 8x8 board, standard initial position, normal chess rules + sudoku.
But theoretically, there's nothing in the variant implementation that prevents using it with:
- `LARGEBOARDS` compilation option.
- Boards of different sizes.
- Mixed with other chess variants.

Issues and potential improvements:
- Variant doesn't detect stalemates (because of replacing king with commoner).
- Position evaluation doesn't take variant specifics into account yet.
- `do_move` re-calculates the sudoku conflicts map from the scratch. It should be possible to optimize.

Sorry for a large PR! It's the smallest possible chunk of changes that will have a value for the variant support.