### PR TITLE
Upload artifacts for ffish.js builds in CI

### DIFF
--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -43,7 +43,32 @@ jobs:
       - name: Run unit tests
         working-directory: tests/js
         run: npm test
-      - name: Build ffish.js ES6/ES2015 module (Installation information is kept)
+
+  build:
+    runs-on: ubuntu-20.04
+    needs: [test]    #Building process must start after successful testing process
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup cache
+        id: cache-system-libraries
+        uses: actions/cache@v2
+        with:
+          path: ${{env.EM_CACHE_FOLDER}}
+          key: emsdk-${{env.EM_VERSION}}-${{ runner.os }}
+      - uses: mymindstorm/setup-emsdk@v7
+        with:
+          version: ${{env.EM_VERSION}}
+          actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build ffish.js ES6/ES2015 module
         working-directory: src
         run: rm -f ../tests/js/ffish.js & rm -f ../tests/js/ffish.wasm & make -f Makefile_js build es6=yes
       - name: Upload ffish.js ES6/ES2015 module ZIP archive
@@ -53,7 +78,7 @@ jobs:
           path: tests/js/*
           if-no-files-found: error
           compression-level: 9
-      - name: Build ffish.js standard module (Installation information is kept)
+      - name: Build ffish.js standard module
         working-directory: src
         run: rm -f ../tests/js/ffish.js & rm -f ../tests/js/ffish.wasm & make -f Makefile_js build
       - name: Upload ffish.js standard module ZIP archive

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -43,3 +43,23 @@ jobs:
       - name: Run unit tests
         working-directory: tests/js
         run: npm test
+      - name: Build ffish.js ES6/ES2015 module (Installation information is kept)
+        working-directory: src
+        run: rm -f ../tests/js/ffish.js & rm -f ../tests/js/ffish.wasm & make -f Makefile_js build es6=yes
+      - name: Upload ffish.js ES6/ES2015 module ZIP archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffishjs-es6
+          path: tests/js/*
+          if-no-files-found: error
+          compression-level: 9
+      - name: Build ffish.js standard module (Installation information is kept)
+        working-directory: src
+        run: rm -f ../tests/js/ffish.js & rm -f ../tests/js/ffish.wasm & make -f Makefile_js build
+      - name: Upload ffish.js standard module ZIP archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffishjs-standard
+          path: tests/js/*
+          if-no-files-found: error
+          compression-level: 9


### PR DESCRIPTION
After this change, I created a new job in ffishjs.yml to automatically build and upload ffish.js so that ffish.js can be built automatically in the CI environment. I used the custom build in [https://github.com/yjf2002ghty/Fairy-Stockfish/blob/make_js/.github/workflows/make_js.yml](https://github.com/yjf2002ghty/Fairy-Stockfish/blob/make_js/.github/workflows/make_js.yml) and it works in fairyground by replacing the node module with the custom build. This can avoid setting up environment and build it on our machine and thus saving time.