### PR TITLE
chore(license): update license classifier to `GPL-3.0-or-later`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if "64bit" in platform.architecture():
 
 CLASSIFIERS = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)",
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Update to use SPDX license identifier, which also matches with the license header.

relates to https://github.com/Homebrew/homebrew-core/pull/200703/