### PR TITLE
Update workflow action version

### DIFF
--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -56,16 +56,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup cache
         id: cache-system-libraries
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{env.EM_CACHE_FOLDER}}
           key: emsdk-${{env.EM_VERSION}}-${{ runner.os }}
-      - uses: mymindstorm/setup-emsdk@v7
+      - uses: mymindstorm/setup-emsdk@v14
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build ffish.js ES6/ES2015 module

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,12 @@ jobs:
         if: ${{ matrix.arch == 'x86-64' }}
         run: cd src && make clean && make -j build COMP=mingw ARCH=${{ matrix.arch }} EXE=fairy-stockfish-all_${{ matrix.arch }}.exe largeboards=yes all=yes && strip fairy-stockfish-all_${{ matrix.arch }}.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: fairy-stockfish
           path: src/fairy-stockfish*.exe
+          if-no-files-found: error
+          compression-level: 9
 
   linux:
     strategy:
@@ -56,7 +58,9 @@ jobs:
         if: ${{ matrix.arch == 'x86-64' }}
         run: cd src && make clean && make -j build COMP=gcc ARCH=${{ matrix.arch }} EXE=fairy-stockfish-all_${{ matrix.arch }} largeboards=yes all=yes && strip fairy-stockfish-all_${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: fairy-stockfish
           path: src/fairy-stockfish*
+          if-no-files-found: error
+          compression-level: 9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: fairy-stockfish
+          name: fairy-stockfish-windows-${{ matrix.arch }}
           path: src/fairy-stockfish*.exe
           if-no-files-found: error
           compression-level: 9
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: fairy-stockfish
+          name: fairy-stockfish-linux-${{ matrix.arch }}
           path: src/fairy-stockfish*
           if-no-files-found: error
           compression-level: 9

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,9 +34,9 @@ jobs:
           CIBW_SKIP: "pp* *-win32 *-manylinux_i686 *-musllinux_* cp36-* cp37-*"
           CIBW_TEST_COMMAND: python {project}/test.py
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-wheel-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -53,6 +53,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-source
           path: dist/*.tar.gz
-          if-no-files-found: error


### PR DESCRIPTION
**build (12.x)**
Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down


**Deprecation notice: v1, v2, and v3 of the artifact actions**
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "fairy-stockfish".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/