### PR TITLE
Fix pyffish License classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if "64bit" in platform.architecture():
 
 CLASSIFIERS = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Uploading pyffish to pypi.org fails atm:
```
Uploading pyffish-0.0.85-cp310-cp310-macosx_10_14_x86_64.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 576.5/576.5 kB • 00:00 • 1.0 MB/s
INFO     Response from https://upload.pypi.org/legacy/:                                                                                             
         400 'License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)' is not a valid classifier. See                  
         https://packaging.python.org/specifications/core-metadata for more information.                                                            
INFO     <html>                                                                                                                                     
          <head>                                                                                                                                    
           <title>400 'License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)' is not a valid classifier. See         
         https://packaging.python.org/specifications/core-metadata for more information.</title>                                                    
          </head>                                                                                                                                   
          <body>                                                                                                                                    
           <h1>400 'License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)' is not a valid classifier. See            
         https://packaging.python.org/specifications/core-metadata for more information.</h1>                                                       
           The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>                              
         &#x27;License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)&#x27; is not a valid classifier. See            
         https://packaging.python.org/specifications/core-metadata for more information.                                                            
                                                                                                                                                    
                                                                                                                                                    
          </body>                                                                                                                                   
         </html>                                                                                                                                    
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                            
         'License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)' is not a valid classifier. See                      
         https://packaging.python.org/specifications/core-metadata for more information.                                                            
```
Correct classifiers are listed here https://pypi.org/classifiers/