### PR TITLE
Fix bug with antichess K vs N

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1033,7 +1033,7 @@ Value Endgame<RK, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 }
 
 
-/// K vs N. The king usally wins, but there are a few exceptions.
+/// K vs N. The king usually wins, but there are a few exceptions.
 template<>
 Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
@@ -1045,11 +1045,13 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
   Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq);
   bool strongSideToMove = pos.side_to_move() == strongSide;
 
-  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq) return mated_in(1);
-  if (kingAttacks & knightAttacks) return mate_in(2);
-  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq) return mated_in(3);
+  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq) return VALUE_TB_LOSS_IN_MAX_PLY + 1;
+  if (kingAttacks & knightAttacks) return VALUE_TB_WIN_IN_MAX_PLY - 2;
+  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq) return VALUE_TB_LOSS_IN_MAX_PLY + 3;
 
-  Value result = VALUE_KNOWN_WIN + push_to_edge(NSq, pos) - push_to_edge(KSq, pos);
+  Value result = Value(push_to_edge(NSq, pos)) - push_to_edge(KSq, pos);
+  if (!(KSq & (SQ_A1 | SQ_A8 | SQ_H1 | SQ_H8)))
+      result += VALUE_KNOWN_WIN;
 
   return strongSideToMove ? result : -result;
 }

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1041,16 +1041,17 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
   Square KSq = pos.square<COMMONER>(strongSide);
   Square NSq = pos.square<KNIGHT>(weakSide);
+  Bitboard kingAttacks = attacks_bb<KING>(KSq);
+  Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq);
+  bool strongSideToMove = pos.side_to_move() == strongSide;
 
-  // wins for knight
-  if (pos.side_to_move() == strongSide && (attacks_bb<KNIGHT>(NSq) & KSq) && !(attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
-      return -VALUE_KNOWN_WIN;
-  if (pos.side_to_move() == weakSide && (attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
-      return VALUE_KNOWN_WIN;
+  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq) return mated_in(1);
+  if (kingAttacks & knightAttacks) return mate_in(2);
+  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq) return mated_in(3);
 
   Value result = VALUE_KNOWN_WIN + push_to_edge(NSq, pos) - push_to_edge(KSq, pos);
 
-  return strongSide == pos.side_to_move() ? result : -result;
+  return strongSideToMove ? result : -result;
 }
 
 /// N vs N. The side to move always wins/loses if the knights are on

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1032,35 +1032,6 @@ Value Endgame<RK, EG_EVAL_ANTI>::operator()(const Position& pos) const {
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
-Value winInX(Square KSq, Square NSq, bool strongSideToMove, bool recurse)
-{
-    Bitboard kingAttacks = attacks_bb<KING>(KSq);
-    Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq);
-    if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq)
-        return VALUE_TB_LOSS_IN_MAX_PLY + 1;
-    if (kingAttacks & knightAttacks)
-        return VALUE_TB_WIN_IN_MAX_PLY - 2;
-    if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq)
-        return VALUE_TB_LOSS_IN_MAX_PLY + 3;
-    if (KSq & (SQ_A1 | SQ_A8 | SQ_H1 | SQ_H8) && distance<File>(KSq, NSq) == 3 && distance<Rank>(KSq, NSq) == 3)
-        return strongSideToMove ? VALUE_TB_LOSS_IN_MAX_PLY + 3 : VALUE_TB_WIN_IN_MAX_PLY - 4;
-    if (!recurse)
-        return Value(0);
-    Bitboard sideToMoveAttacks = strongSideToMove ? kingAttacks : knightAttacks;
-    Value best = VALUE_TB_LOSS_IN_MAX_PLY;
-    while (sideToMoveAttacks && best <= 0)
-    {
-       Square currMove = pop_lsb(sideToMoveAttacks);
-       Square newKSq = strongSideToMove ? currMove : KSq;
-       Square newNSq = strongSideToMove ? NSq : currMove;
-
-       best = std::max(-winInX(newKSq, newNSq, !strongSideToMove, false), best);
-        // todo - prob doesn't matter, but could compensate for being a ply deeper in recursive call?
-        // also only recurse in certain conditions? Like K and N being certain distance apart.
-          // maybe only when it's knight's turn? Not sure about this one.
-    }
-    return best;
-}
 
 /// K vs N. The king usually wins, but there are a few exceptions.
 template<>
@@ -1070,10 +1041,25 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
   Square KSq = pos.square<COMMONER>(strongSide);
   Square NSq = pos.square<KNIGHT>(weakSide);
+  Bitboard kingAttacks = attacks_bb<KING>(KSq) & pos.board_bb();
+  Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq) & pos.board_bb();
   bool strongSideToMove = pos.side_to_move() == strongSide;
-  Value definitive = winInX(KSq, NSq, strongSideToMove, true);
-  if (definitive != 0) return definitive;
-  Value result = Value(VALUE_KNOWN_WIN + push_to_edge(NSq, pos) - push_to_edge(KSq, pos));
+
+  // Loss in 1 play
+  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq)
+      return VALUE_TB_LOSS_IN_MAX_PLY + 1;
+  // Win in 2 ply
+  if (kingAttacks & knightAttacks)
+      return VALUE_TB_WIN_IN_MAX_PLY - 2;
+  // Loss in 3 ply
+  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq)
+      return VALUE_TB_LOSS_IN_MAX_PLY + 3;
+
+  Value result = Value(push_to_edge(NSq, pos)) - push_to_edge(KSq, pos);
+  // The king usually wins, but scenarios with king on the edge are more complicated
+  if (!(KSq & (FileABB | FileHBB | Rank1BB | Rank8BB)))
+      result += VALUE_KNOWN_WIN;
+
   return strongSideToMove ? result : -result;
 }
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1041,17 +1041,16 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
   Square KSq = pos.square<COMMONER>(strongSide);
   Square NSq = pos.square<KNIGHT>(weakSide);
-  Bitboard kingAttacks = attacks_bb<KING>(KSq);
-  Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq);
-  bool strongSideToMove = pos.side_to_move() == strongSide;
 
-  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq) return mated_in(1);
-  if (kingAttacks & knightAttacks) return mate_in(2);
-  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq) return mated_in(3);
+  // wins for knight
+  if (pos.side_to_move() == strongSide && (attacks_bb<KNIGHT>(NSq) & KSq) && !(attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
+      return -VALUE_KNOWN_WIN;
+  if (pos.side_to_move() == weakSide && (attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
+      return VALUE_KNOWN_WIN;
 
   Value result = VALUE_KNOWN_WIN + push_to_edge(NSq, pos) - push_to_edge(KSq, pos);
 
-  return strongSideToMove ? result : -result;
+  return strongSide == pos.side_to_move() ? result : -result;
 }
 
 /// N vs N. The side to move always wins/loses if the knights are on

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1041,16 +1041,17 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
 
   Square KSq = pos.square<COMMONER>(strongSide);
   Square NSq = pos.square<KNIGHT>(weakSide);
+  Bitboard kingAttacks = attacks_bb<KING>(KSq);
+  Bitboard knightAttacks = attacks_bb<KNIGHT>(NSq);
+  bool strongSideToMove = pos.side_to_move() == strongSide;
 
-  // wins for knight
-  if (pos.side_to_move() == strongSide && (attacks_bb<KING>(KSq) & NSq))
-      return -VALUE_KNOWN_WIN;
-  if (pos.side_to_move() == weakSide && (attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
-      return VALUE_KNOWN_WIN;
+  if (strongSideToMove ? kingAttacks & NSq : knightAttacks & KSq) return mated_in(1);
+  if (kingAttacks & knightAttacks) return mate_in(2);
+  if (strongSideToMove ? knightAttacks & KSq : kingAttacks & NSq) return mated_in(3);
 
   Value result = VALUE_KNOWN_WIN + push_to_edge(NSq, pos) - push_to_edge(KSq, pos);
 
-  return strongSide == pos.side_to_move() ? result : -result;
+  return strongSideToMove ? result : -result;
 }
 
 /// N vs N. The side to move always wins/loses if the knights are on

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -1043,7 +1043,7 @@ Value Endgame<KN, EG_EVAL_ANTI>::operator()(const Position& pos) const {
   Square NSq = pos.square<KNIGHT>(weakSide);
 
   // wins for knight
-  if (pos.side_to_move() == strongSide && (attacks_bb<KNIGHT>(NSq) & KSq))
+  if (pos.side_to_move() == strongSide && (attacks_bb<KING>(KSq) & NSq))
       return -VALUE_KNOWN_WIN;
   if (pos.side_to_move() == weakSide && (attacks_bb<KNIGHT>(NSq) & attacks_bb<KING>(KSq)))
       return VALUE_KNOWN_WIN;


### PR DESCRIPTION
- In the first if statement of the diff, `if (pos.side_to_move() == strongSide && (attacks_bb<KNIGHT>(NSq) & KSq))` is a bug. I think the intention is to see if the king is attacking the knight, so I fixed it to that.
- In some cases where the king is to move and it's on the edge (e.g., Kg1 and Ne2), the knight attacking the king actually does mean that the knight wins (but only if the king is not attacking any other squares the knight attacks). So I rewrote the code to handle all cases where the king and knight attack each other or share attacks.

Briefly tested with a few positions, but haven't done a fishtest (http://www.variantfishtest.org:6543/tests doesn't load for me).