### PR TITLE
Update Dragonfly variant rules in variants.ini

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -1041,7 +1041,7 @@ promotedPieceType = l:g n:g
 pieceToCharTable = P....SLN.G.+....+Kp....sln.g.+....+k
 
 # Dragonfly
-# Simplified Crazyhouse. Two rules have been removed from the original definition (Removing captured pawns and special pawn promotion). Credits to Procyon for the definition.
+# Simplified Crazyhouse. Special pawn promotion rules from the original definition are not implemented. Credits to Procyon for the definition.
 # https://en.wikipedia.org/wiki/Dragonfly_(chess_variant)
 [dragonfly:chess]
 maxFile = 7
@@ -1057,7 +1057,7 @@ promotionPieceTypes = nbr
 doubleStep = false
 dropNoDoubled = p
 dropNoDoubledCount = 0
-startFen = rbbknnr/ppppppp/7/7/7/PPPPPPP/RBBKNNR[] w - - 0 1
+startFen = rbbknnr/ppppppp/7/7/7/PPPPPPP/RBBKNNR[] w KQkq - 0 1
 
 # Kamikaze Rooks
 # The objective of the game is to lose both rooks. Credits to Procyon for the definition.


### PR DESCRIPTION
dropNoDoubledCount = 0 causes to prevent pawn drops, so the original rule to not allow captured pawns to be dropped is enforced. Also to enable castling adding castling rights to the startFen is fixed.