### PR TITLE
Test Capahouse moves with populated pockets

### DIFF
--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -166,6 +166,7 @@ if [[ $1 == "all" ||  $1 == "largeboard" ]]; then
   expect perft.exp shoshogi startpos 4 445372 > /dev/null  # configurable pieces
   expect perft.exp yarishogi startpos 4 158404 > /dev/null  # configurable pieces
   expect perft.exp capablanca startpos 4 805128 > /dev/null
+  expect perft.exp capahouse "fen 3k6/10/10/10/10/10/10/4K5[CAQRBNPcaqrbnp] w - - 0 1" 2 234785 > /dev/null
   expect perft.exp embassy startpos 4 809539 > /dev/null
   expect perft.exp janus startpos 4 772074 > /dev/null
   expect perft.exp modern startpos 4 433729 > /dev/null


### PR DESCRIPTION
## What changed

Add a large-board perft regression for a Capahouse position with both pockets populated.

## Why

The existing Capablanca perft covers ordinary 10x8 move generation, while the current pocket tests cover 8x8 variants. This position exercises Capablanca compound-piece drops, pocket ownership, and the much larger legal move set produced by populated Capahouse reserves.

The expected depth-two count was independently reproduced with a separate Capablanca move generator.

## Validation

- `make -j2 ARCH=apple-silicon largeboards=yes all=yes build`
- `./stockfish check variants.ini`
- `../tests/perft.sh largeboard`
- `../tests/perft.sh all`