### PR TITLE
Fix XBoard Chess960 castling notation

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -534,6 +534,9 @@ string UCI::move(const Position& pos, Move m) {
   string move = (type_of(m) == DROP ? UCI::dropped_piece(pos, m) + (CurrentProtocol == USI ? '*' : '@')
                                     : UCI::square(pos, from)) + UCI::square(pos, to);
 
+  if (CurrentProtocol == XBOARD && pos.is_chess960() && type_of(m) == CASTLING)
+      move = to > from ? "O-O" : "O-O-O";
+
   // Wall square
   if (pos.walling() && CurrentProtocol == XBOARD)
       move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
@@ -569,7 +572,7 @@ Move UCI::to_move(const Position& pos, string& str) {
       if (str[4] == '=')
           // shogi moves refraining from promotion might use equals sign
           str.pop_back();
-      else
+      else if (str != "O-O-O")
           // Junior could send promotion piece in uppercase
           str[4] = char(tolower(str[4]));
   }

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -71,6 +71,16 @@ cat << EOF > xboard.exp
    expect "pong"
    send "variant 3check-crazyhouse\\n"
    expect "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR\\\\\[] w KQkq - 3+3 0 1"
+   send "variant fischerandom\\n"
+   send "setboard 4k3/8/8/8/8/8/8/R3K2R w HA - 0 1\\n"
+   send "force\\n"
+   send "usermove O-O\\n"
+   send "d\\n"
+   expect "Fen: 4k3/8/8/8/8/8/8/R4RK1 b - - 1 1"
+   send "setboard 4k3/8/8/8/8/8/8/R3K2R w HA - 0 1\\n"
+   send "usermove O-O-O\\n"
+   send "d\\n"
+   expect "Fen: 4k3/8/8/8/8/8/8/2KR3R b - - 1 1"
    send "quit\\n"
    expect eof
 EOF


### PR DESCRIPTION
Fixes #941.

XBoard now emits CECP-compliant `O-O` and `O-O-O` for Chess960 castling. The move parser preserves the final uppercase `O` in queenside castling rather than treating it as an uppercase promotion suffix.

The XBoard protocol regression verifies both castling directions are accepted and produce the correct resulting FEN. This exercises the same `UCI::move` representation used for protocol output and parsing.

Validation:
- `make -j2 ARCH=apple-silicon build`
- generated XBoard Expect regression passed directly
- `./stockfish bench`

The repository wrapper `tests/protocol.sh` could not run end-to-end on this macOS host because GNU `timeout` is not installed.