### PR TITLE
Count checks against pseudo-royal pieces

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1593,9 +1593,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
   assert(type_of(captured) != KING);
 
-  if (check_counting() && givesCheck)
-      k ^= Zobrist::checks[us][st->checksRemaining[us]] ^ Zobrist::checks[us][--(st->checksRemaining[us])];
-
   if (type_of(m) == CASTLING)
   {
       assert(type_of(pc) != NO_PIECE_TYPE);
@@ -2112,6 +2109,12 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
   // Update king attacks used for fast check detection
   set_check_info(st);
+
+  if (check_counting() && (givesCheck || (extinction_pseudo_royal() && checked_pseudo_royals(sideToMove))))
+  {
+      st->key ^= Zobrist::checks[us][st->checksRemaining[us]]
+               ^ Zobrist::checks[us][--(st->checksRemaining[us])];
+  }
 
   // Calculate the repetition info. It is the ply distance from the previous
   // occurrence of the same position, negative in the 3-fold case, or zero

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -60,6 +60,20 @@ cat << EOF > ucicyclone2.exp
    expect eof
 EOF
 
+cat << EOF > pseudo_royal_check_count.exp
+   spawn ./stockfish load ../tests/pseudo_royal_check_count.ini
+   send "setoption name UCI_Variant value pseudo-royal-check-count\\n"
+   send "position startpos moves d1e1\\n"
+   send "d\\n"
+   expect "Fen: 4n3/8/8/8/8/8/8/4Q3 b - - 8+9 1 1"
+   send "setoption name UCI_Variant value pseudo-royal-duple-check-count\\n"
+   send "position startpos moves d1e1\\n"
+   send "d\\n"
+   expect "Fen: 4n3/8/8/8/7n/8/8/4Q3 b - - 8+9 1 1"
+   send "quit\\n"
+   expect eof
+EOF
+
 cat << EOF > xboard.exp
    spawn ./stockfish load variants.ini
    send "xboard\\n"
@@ -75,7 +89,7 @@ cat << EOF > xboard.exp
    expect eof
 EOF
 
-for exp in uci.exp ucci.exp usi.exp ucicyclone.exp ucicyclone2.exp xboard.exp
+for exp in uci.exp ucci.exp usi.exp ucicyclone.exp ucicyclone2.exp pseudo_royal_check_count.exp xboard.exp
 do
   echo "Testing $exp"
   timeout 5 expect $exp > /dev/null

--- a/tests/pseudo_royal_check_count.ini
+++ b/tests/pseudo_royal_check_count.ini
@@ -1,0 +1,14 @@
+[pseudo-royal-check-count]
+knight = n
+queen = q
+king = -
+castling = false
+extinctionValue = loss
+extinctionPieceTypes = *
+extinctionPseudoRoyal = true
+checkCounting = true
+startFen = 4n3/8/8/8/8/8/8/3Q4 w - - 9+9 0 1
+
+[pseudo-royal-duple-check-count:pseudo-royal-check-count]
+dupleCheck = true
+startFen = 4n3/8/8/8/7n/8/8/3Q4 w - - 9+9 0 1


### PR DESCRIPTION
Fixes #975.

Check counting now recognizes checks against extinction pseudo-royal pieces after the resulting board state is available. The counter is incorporated into the resulting position key after pseudo-royal detection is refreshed.

The regression covers both a single pseudo-royal and a duple-check position. In each case, `Qe1` changes the check counter from `9+9` to `8+9`.

Validation:
- `make -j2 ARCH=apple-silicon build`
- `../tests/perft.sh chess`
- focused Expect regression passed directly
- `./stockfish bench`

The repository protocol wrapper could not run end-to-end on this macOS host because GNU `timeout` is not installed.