### PR TITLE
Treat SEE as neutral in Misere

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2492,7 +2492,9 @@ bool Position::see_ge(Move m, Value threshold) const {
       return extinction_value() < VALUE_ZERO;
 
   // Do not evaluate SEE if value would be unreliable
-  if (must_capture() || !checking_permitted() || is_gating(m) || count<CLOBBER_PIECE>() == count<ALL_PIECES>())
+  if (   endgame_eval() == EG_EVAL_MISERE
+      || must_capture() || !checking_permitted() || is_gating(m)
+      || count<CLOBBER_PIECE>() == count<ALL_PIECES>())
       return VALUE_ZERO >= threshold;
 
   int swap = PieceValue[MG][piece_on(to)] - threshold;


### PR DESCRIPTION
SEE is based on the idea that losing material is bad, which is not true in Misere.

This patch treats SEE as neutral in Misere.

## Example

At 2,000 nodes with the Misere NNUE:

```text
4Q2b/8/5k2/8/8/8/P7/KB4R1 w - - 0 1
```

Before the patch, Fairy chooses `g1g2` and the game draws. With the patch it finds `g1g7`, reports `mate 2`, and forces its own checkmate.

## Results

- 512-game tactical validation: 118 wins, 342 draws, 52 losses (`+44.95` Elo-like; 95% CI `+33.97` to `+56.71`).
- 2,048-game broad screen: 9 wins, 2,034 draws, 5 losses (`+0.68`; confidence interval crosses zero).

This patch fixes a real forced-selfmate blind spot.
No changes for non-misère variants.
