### PR TITLE
Fix castling notation in ffish.js moveStack()

### DIFF
--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -84,6 +84,9 @@ private:
   Position pos;
   Thread* thread;
   std::vector<Move> moveStack;
+  // UCI notation of the moves in moveStack, recorded at the time the move is made,
+  // since conversion of a move to UCI notation can depend on the position, e.g., for castling.
+  std::vector<std::string> uciMoveStack;
   bool is960;
 
 public:
@@ -160,6 +163,7 @@ public:
   void pop() {
     pos.undo_move(this->moveStack.back());
     moveStack.pop_back();
+    uciMoveStack.pop_back();
     states->pop_back();
   }
 
@@ -186,6 +190,7 @@ public:
   void set_fen(std::string fen) {
     resetStates();
     moveStack.clear();
+    uciMoveStack.clear();
     pos.set(v, fen, is960, &states->back(), thread);
   }
 
@@ -349,8 +354,8 @@ public:
 
   std::string move_stack() const {
     std::string moves;
-    for(auto it = std::begin(moveStack); it != std::end(moveStack); ++it) {
-      moves += UCI::move(pos, *it);
+    for(auto it = std::begin(uciMoveStack); it != std::end(uciMoveStack); ++it) {
+      moves += *it;
       moves += DELIM;
     }
     save_pop_back(moves);
@@ -431,6 +436,7 @@ private:
   }
 
   void do_move(Move move) {
+    this->uciMoveStack.emplace_back(UCI::move(pos, move));
     states->emplace_back();
     this->pos.do_move(move, states->back());
     this->moveStack.emplace_back(move);

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -623,6 +623,23 @@ describe('board.moveStack()', function () {
     chai.expect(board.moveStack()).to.equal("h5f7");
     board.delete();
   });
+  it("it keeps non-960 castling notation when later moves obscure it (issue #911)", () => {
+    // After castling, the rook returns to the king's origin square e8 and the king
+    // vacates g8, which used to flip the rendered castling move to 960 notation e8h8.
+    let board = new ffish.Board("chess");
+    const chessMoves = "e2e4 e7e5 g1f3 g8f6 f1c4 f8c5 d2d3 e8g8 c1g5 f8e8 b1c3 g8h8 a2a3";
+    board.pushMoves(chessMoves);
+    chai.expect(board.moveStack()).to.equal(chessMoves);
+    board.delete();
+    board = new ffish.Board("seirawan", "4kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EH] w KQBCDFGk - 0 1");
+    const moves = "e2e4 g8f6 e4e5 f6d5 c2c4 d5b4 a2a3 b4c6 d2d4 e7e6 b1c3h f8e7 g1f3e e7d8 b2b4 c6e7 " +
+                  "b1e4 a7a6 h2h4 h7h6 e4b7 e8g8 g2g4 a6a5 b4a5 c7c5 d4c5 g8h7 d1d7 h7h8 a5a6 e7g6 " +
+                  "a6a7 d8a5 b7a5 h8h7 g4g5 h6h5 g1g3 g6f4 c1f4 g7g6 a1b1 h7g8 b1b8 g8g7 b8f8 g7f8 " +
+                  "a7a8q f8g7 a8e8 g7h7";
+    board.pushMoves(moves);
+    chai.expect(board.moveStack()).to.equal(moves);
+    board.delete();
+  });
 });
 
 describe('board.pushMoves(uciMoves)', function () {


### PR DESCRIPTION
Fixes #911.

`Board.moveStack()` (and thus `Game.mainlineMoves()`) converted the stored moves relative to the *current* position instead of the position each move was played from. Since 2611663b, `UCI::move()` falls back to chess960-style castling notation when the non-960 notation is ambiguous with a normal move in the given position. As a result, a castling move could retroactively be rendered in 960 notation once a later move placed a piece on the castling king's origin square while the castling side was to move — e.g., in the seirawan repro from #911, the promoted queen arriving on e8 via `a8e8` flipped the earlier `e8g8` to `e8h8`. This also explains the pychess server crashes reported in the issue comments, where `readGamePGN().mainlineMoves()` emitted an `e8h8` that could not be replayed.

Fix: record the UCI notation at the time each move is made (when the position is the one the move is played from) in a parallel string stack, and have `move_stack()` return the recorded strings. `UCI::move()` itself is unchanged; the remaining stale-position callers (PV/ponder output) are unaffected because a castling move in the line implies the king still sits on its origin square at root.

Added a regression test with a plain-chess trigger sequence and the exact seirawan repro from the issue. Verified with an emsdk 1.39.16 build that the test fails with the reported `e8h8` output before the fix and that the full JS suite (60 tests) passes after; `test.py` (including the #295 ambiguous-castling test) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)