### PR TITLE
Allocate MovePicker move buffers from a per-thread pool

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -17,6 +17,8 @@
 */
 
 #include <cassert>
+#include <memory>
+#include <vector>
 
 #include "movepick.h"
 
@@ -53,8 +55,30 @@ namespace {
         }
   }
 
+  // Per-thread LIFO pool of move buffers. MovePicker instances have strictly
+  // nested lifetimes within a search thread, so buffers can be handed out and
+  // returned stack-wise. This keeps the large MAX_MOVES array off the machine
+  // stack, whose 8MB limit deep searches can otherwise exceed (see issue #957).
+  thread_local std::vector<std::unique_ptr<ExtMove[]>> moveBuffers;
+  thread_local size_t usedMoveBuffers = 0;
+
+  ExtMove* acquire_move_buffer() {
+    if (usedMoveBuffers == moveBuffers.size())
+        moveBuffers.emplace_back(new ExtMove[MAX_MOVES]);
+    return moveBuffers[usedMoveBuffers++].get();
+  }
+
+  void release_move_buffer() {
+    assert(usedMoveBuffers > 0);
+    --usedMoveBuffers;
+  }
+
 } // namespace
 
+
+MovePicker::~MovePicker() {
+  release_move_buffer();
+}
 
 /// Constructors of the MovePicker class. As arguments we pass information
 /// to help it to return the (presumably) good moves first, to decide which
@@ -66,7 +90,7 @@ namespace {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh, const LowPlyHistory* lp,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, const Move* killers, int pl)
            : pos(p), mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
-             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl) {
+             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl), moves(acquire_move_buffer()) {
 
   assert(d > 0);
 
@@ -77,7 +101,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), recaptureSquare(rs), depth(d) {
+           : pos(p), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), recaptureSquare(rs), depth(d), moves(acquire_move_buffer()) {
 
   assert(d <= 0);
 
@@ -90,7 +114,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory* dh, const CapturePieceToHistory* cph)
-           : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), threshold(th) {
+           : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), threshold(th), moves(acquire_move_buffer()) {
 
   assert(!pos.checkers());
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -126,6 +126,7 @@ class MovePicker {
 public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
+  ~MovePicker();
   MovePicker(const Position&, Move, Value, const GateHistory*, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
                                            const GateHistory*,
@@ -161,7 +162,10 @@ private:
   Value threshold;
   Depth depth;
   int ply;
-  ExtMove moves[MAX_MOVES];
+  // Move buffer taken from a per-thread pool. Keeping it off the stack bounds
+  // the per-frame stack usage of the recursive search, which would otherwise
+  // overflow the 8MB thread stack in deep searches when MAX_MOVES is large.
+  ExtMove* moves;
 };
 
 } // namespace Stockfish


### PR DESCRIPTION
## What

Moves `MovePicker`'s `ExtMove moves[MAX_MOVES]` array off the machine stack into a per-thread `thread_local` LIFO buffer pool. MovePicker instances have strictly nested lifetimes within a search thread, so buffers are handed out and returned stack-wise; after warm-up there are no allocations on the search path. This mirrors the existing heap allocation of `MoveList` (`USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST`).

## Why

Root cause analysis of #804 (crash in `coffeehouse` = crazyhouse + `mustCapture`): each `search()`/`qsearch()` frame was dominated by the MovePicker array — **~70 KB/ply in `largeboards=yes all=yes` builds** (MAX_MOVES = 8192) vs ~12 KB/ply in standard builds. `mustCapture` makes deep forced lines routine (early pruning skipped, losing-chess capture extension, LMR disabled), so recursion can approach MAX_PLY = 246 → ~17 MB worst case against the 8 MB thread stack.

This explains the full reproducibility matrix of #804:
- Standard native builds max out at ~3 MB → never crash (why reproduction attempts failed).
- largeboards/all native builds segfault (the #957 position crashes a June-2024 `all=yes` build in seconds; fishnet workers running the *-all binaries).
- The fairyground engine (`fairy-stockfish-nnue.wasm` npm package) **is** a largeboards+all build; emscripten thread stacks are plain `memalign` heap blocks without guard pages, so the overflow first silently corrupts adjacent memory — matching the reported invalid move in the second MultiPV line — before the `RuntimeError: index out of bounds` trap. Larger hash → more TT cutoffs truncating deep forced lines → fewer crashes, as reported.
- The reporter's variants.ini inheritance workaround is semantically identical to the original definition (only `variantTemplate` differs) — the apparent fix was coincidence.

## Measurements

- `bench` is node-identical to master (6,180,480); speed within noise.
- #804 repro (coffeehouse, threads 4, MultiPV 2, hash 256, `largeboards=yes all=yes`, instrumented): peak stack **4,645 KB at ply 67 → 386 KB at ply 73** (~12×).
- #957 position with the #958 qsearch depth limit (`DEPTH_QS_MAX`) experimentally removed: no crash, peak ~1 MB, position solved quickly — the qsearch limit is no longer needed as a crash guard (whether to keep it as a search heuristic is a separate question; this PR does not touch it).
- Counter-test: putting `MoveList` back on the stack re-inflates frames to ~68 KB/ply despite this fix, so the heap MoveList must stay (pooling it the same way could additionally remove its per-`generate()` malloc/free — possible follow-up).

## Notes for review

- Buffer pool memory per thread is bounded by the deepest nesting reached (worst case ~246 × 64 KB ≈ 16 MB per thread in all-variants builds, allocated lazily; ~2 MB in standard builds) — heap instead of stack, so no overflow risk.
- Wasm smoke test done (fairy-stockfish.wasm nnue branch, emsdk 2.0.26 docker, `ARCH=wasm embedded_nnue=no`): builds clean; single-thread `bench` node-identical to the unpatched baseline (6,257,668); 4-thread bench and the #804 coffeehouse repro (threads 4, MultiPV 2, hash 256) run to depth 11 (92.5M nodes) without errors — this codebase's first `thread_local` works across wasm pthreads. (Multi-threaded bench node counts are inherently nondeterministic, verified baseline-vs-baseline.)
- Not yet done: strength test under real time control (bench only proves search identity).

Addresses #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
