### PR TITLE
bent riders

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -37,6 +37,7 @@ Bitboard PseudoMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard LeaperAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard LeaperMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard BoardSizeBB[FILE_NB][RANK_NB];
+Bitboard RayBB[8][SQUARE_NB];
 RiderType AttackRiderTypes[PIECE_TYPE_NB];
 RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
 
@@ -107,7 +108,9 @@ namespace {
                                                             {EAST  + 2 * SOUTH_EAST, 0}, {SOUTH + 2 * SOUTH_EAST, 0},
                                                             {SOUTH + 2 * SOUTH_WEST, 0}, {WEST  + 2 * SOUTH_WEST, 0},
                                                             {WEST  + 2 * NORTH_WEST, 0}, {NORTH + 2 * NORTH_WEST, 0} };
-  const std::map<Direction, int> GrasshopperDirectionsV { {NORTH, 1}, {SOUTH, 1}};
+  // Bent riders: the key is the direction of the first (single step) leg.
+const std::map<Direction, int> GriffonDirections { {NORTH_EAST, 0}, {SOUTH_EAST, 0}, {SOUTH_WEST, 0}, {NORTH_WEST, 0} };
+const std::map<Direction, int> GrasshopperDirectionsV { {NORTH, 1}, {SOUTH, 1}};
   const std::map<Direction, int> GrasshopperDirectionsH { {EAST, 1}, {WEST, 1} };
   const std::map<Direction, int> GrasshopperDirectionsD { {NORTH_EAST, 1}, {SOUTH_EAST, 1}, {SOUTH_WEST, 1}, {NORTH_WEST, 1} };
 
@@ -186,7 +189,21 @@ namespace {
     return b;
   }
 
-  Bitboard lame_leaper_attack(std::map<Direction, int> directions, Square s, Bitboard occupied) {
+  void init_rays() {
+
+  for (int i = 0; i < 8; ++i)
+      for (Square s = SQ_A1; s <= SQ_MAX; ++s)
+      {
+          Bitboard b = 0;
+          for (Square t = s + QueenDirections[i];
+               is_ok(t) && distance(t, t - QueenDirections[i]) == 1;
+               t += QueenDirections[i])
+              b |= t;
+          RayBB[i][s] = b;
+      }
+}
+
+Bitboard lame_leaper_attack(std::map<Direction, int> directions, Square s, Bitboard occupied) {
     Bitboard b = 0;
     for (const auto& i : directions)
     {
@@ -198,6 +215,42 @@ namespace {
   }
 
 }
+
+/// griffon_path_bb() returns the squares a Griffon standing on 'from' has to
+/// pass through in order to reach 'to', excluding both end points, or 0 if
+/// 'to' is not reachable or is reached by the plain Ferz step. Unlike a
+/// straight slider, the path depends on which end the piece starts from: a
+/// Griffon on a1 reaches b5 through b2-b3-b4, while a Griffon on b5 reaches
+/// a1 through a4-a3-a2.
+
+Bitboard griffon_path_bb(Square from, Square to) {
+
+  assert(is_ok(from) && is_ok(to));
+
+  int df = file_of(to) - file_of(from);
+  int dr = rank_of(to) - rank_of(from);
+
+  // Reachable iff both offsets are non-zero and at least one of them is 1
+  if (!df || !dr || (std::abs(df) > 1 && std::abs(dr) > 1))
+      return 0;
+
+  Direction sf = df > 0 ? EAST : WEST;
+  Direction sr = dr > 0 ? NORTH : SOUTH;
+  Square corner = Square(from + sf + sr);
+
+  if (corner == to)
+      return 0; // plain Ferz step, nothing in between
+
+  Bitboard b = square_bb(corner);
+  Direction d = std::abs(df) == 1 ? sr : sf;
+  for (Square s = Square(corner + d); s != to; s += d)
+  {
+      assert(is_ok(s));
+      b |= s;
+  }
+  return b;
+}
+
 
 /// safe_destination() returns the bitboard of target square for the given step
 /// from the given square. If the step is off the board, returns empty bitboard.
@@ -276,6 +329,14 @@ void Bitboards::init_pieces() {
                   if (BishopDirections.find(d) != BishopDirections.end())
                       riderTypes |= limit == 1 ? RIDER_GRASSHOPPER_D : RIDER_CANNON_DIAG;
               }
+              // Bent riders. Only the full set of four diagonal legs, i.e. the
+              // Griffon, is supported so far; partial sets and range limits
+              // would need per piece type direction tables.
+              if (!pi->bent[initial][modality].empty())
+              {
+                  assert(pi->bent[initial][modality] == GriffonDirections);
+                  riderTypes |= RIDER_GRIFFON;
+              }
           }
       }
 
@@ -303,6 +364,8 @@ void Bitboards::init_pieces() {
                       }
                       pseudo |= sliding_attack<RIDER>(pi->slider[initial][modality], s, 0, c);
                       pseudo |= sliding_attack<HOPPER_RANGE>(pi->hopper[initial][modality], s, 0, c);
+                      if (!pi->bent[initial][modality].empty())
+                          pseudo |= griffon_attacks_bb(s, 0);
                   }
               }
           }
@@ -361,6 +424,8 @@ void Bitboards::init() {
   init_magics<HOPPER>(GrasshopperTableV, GrasshopperMagicsV, GrasshopperDirectionsV);
   init_magics<HOPPER>(GrasshopperTableD, GrasshopperMagicsD, GrasshopperDirectionsD);
 #endif
+
+  init_rays();
 
   init_pieces();
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -161,6 +161,18 @@ extern Magic GrasshopperMagicsD[SQUARE_NB];
 
 extern Magic* magics[];
 
+// The eight queen directions, in rotational order: rotating by 45 degrees is
+// a +/-1 step in this array. Diagonals sit at the odd indices.
+constexpr Direction QueenDirections[8] = { NORTH, NORTH_EAST, EAST, SOUTH_EAST,
+                                           SOUTH, SOUTH_WEST, WEST, NORTH_WEST };
+
+// RayBB[d][s] holds every square from s to the board edge in direction
+// QueenDirections[d], excluding s. Used to keep only the half of a rook attack
+// set that points away from a bent rider's origin square.
+extern Bitboard RayBB[8][SQUARE_NB];
+
+Bitboard griffon_path_bb(Square from, Square to);
+
 constexpr Bitboard make_bitboard() { return 0; }
 
 template<typename ...Squares>
@@ -326,6 +338,10 @@ inline Bitboard between_bb(Square s1, Square s2, PieceType pt) {
   else if (pt == JANGGI_ELEPHANT)
       return  (PseudoAttacks[WHITE][WAZIR][s2] & PseudoAttacks[WHITE][ALFIL][s1])
             | (PseudoAttacks[WHITE][KNIGHT][s2] & PseudoAttacks[WHITE][FERS][s1]);
+  else if (pt == GRIFFON)
+      // The path of a bent rider depends on which end it starts from, so it
+      // has to be traced from the piece (s2) towards the target (s1).
+      return griffon_path_bb(s2, s1);
   else
       return between_bb(s1, s2);
 }
@@ -461,6 +477,27 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
   }
 }
 
+/// griffon_attacks_bb() returns the bent-rider component of a Griffon: one
+/// diagonal step onto a corner square, which has to be empty for the move to
+/// continue, then an unlimited orthogonal ride away from the origin square.
+/// The corner square itself is not included, it is covered by the Ferz step.
+/// Both continuation directions of a diagonal leg are orthogonal, so a single
+/// rook lookup per corner suffices; RayBB discards the half pointing back.
+
+inline Bitboard griffon_attacks_bb(Square s, Bitboard occupied) {
+
+  Bitboard b = 0;
+  for (int i = 1; i < 8; i += 2) // the four diagonals
+  {
+      Square t = Square(s + QueenDirections[i]);
+      if (!is_ok(t) || distance(s, t) != 1 || (occupied & t))
+          continue;
+      b |= attacks_bb<ROOK>(t, occupied) & (RayBB[(i + 1) & 7][t] | RayBB[(i + 7) & 7][t]);
+  }
+  return b;
+}
+
+
 /// pop_rider() finds and clears a rider in a (hybrid) rider type
 
 inline RiderType pop_rider(RiderType* r) {
@@ -473,6 +510,9 @@ inline RiderType pop_rider(RiderType* r) {
 inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   Bitboard b = LeaperAttacks[c][pt][s];
   RiderType r = AttackRiderTypes[pt];
+  if (r & RIDER_GRIFFON)
+      b |= griffon_attacks_bb(s, occupied);
+  r &= MAGIC_RIDERS;
   while (r)
       b |= rider_attacks_bb(pop_rider(&r), s, occupied);
   return b & PseudoAttacks[c][pt][s];
@@ -483,6 +523,9 @@ template <bool Initial=false>
 inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   Bitboard b = LeaperMoves[Initial][c][pt][s];
   RiderType r = MoveRiderTypes[Initial][pt];
+  if (r & RIDER_GRIFFON)
+      b |= griffon_attacks_bb(s, occupied);
+  r &= MAGIC_RIDERS;
   while (r)
       b |= rider_attacks_bb(pop_rider(&r), s, occupied);
   return b & PseudoMoves[Initial][c][pt][s];

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -178,6 +178,17 @@ namespace {
       }
       return p;
   }
+  // Special multi-leg betza description for the Griffon, a bent rider:
+  // one diagonal step (on which it may stop, hence the Ferz base) followed by
+  // an unlimited orthogonal ride away from the origin square.
+  PieceInfo* griffon_piece() {
+      PieceInfo* p = from_betza("F", "griffon");
+      p->betza = "FyafsF"; // for compatibility with XBoard/Winboard
+      for (Direction d : {NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST})
+          for (MoveModality m : {MODALITY_QUIET, MODALITY_CAPTURE})
+              p->bent[0][m][d] = 0;
+      return p;
+  }
   // Special multi-leg betza description for Janggi elephant
   PieceInfo* janggi_elephant_piece() {
       PieceInfo* p = from_betza("nZ", "janggiElephant");
@@ -224,6 +235,7 @@ void PieceMap::init(const Variant* v) {
   add(WAZIR, from_betza("W", "wazir"));
   add(COMMONER, from_betza("K", "commoner"));
   add(CENTAUR, from_betza("KN", "centaur"));
+  add(GRIFFON, griffon_piece());
   add(KING, from_betza("K", "king"));
   // Add custom pieces
   for (PieceType pt = CUSTOM_PIECES; pt <= CUSTOM_PIECES_END; ++pt)

--- a/src/piece.h
+++ b/src/piece.h
@@ -37,6 +37,13 @@ struct PieceInfo {
   std::map<Direction, int> steps[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> slider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> hopper[2][MOVE_MODALITY_NB] = {};
+  // Bent riders. The key is the direction of the *first* leg; the ride then
+  // continues, without limit, in the two directions obtained by rotating that
+  // first leg by +/- 45 degrees, i.e. away from the origin square. Diagonal
+  // keys describe a Griffon. The corner square is not a destination here: a
+  // piece that may stop there declares the step separately, so that the
+  // Griffon is "F" plus the four bent diagonal legs.
+  std::map<Direction, int> bent[2][MOVE_MODALITY_NB] = {};
 };
 
 struct PieceMap : public std::map<PieceType, const PieceInfo*> {

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -163,6 +163,15 @@ int slider_fraction(std::map<Direction, int> slider) {
 }
 
 
+// A bent leg fans out into two rays, but they are shorter on average than a
+// straight one, so count each leg as one and a half slider directions. On 8x8
+// this puts the Griffon slightly below the queen, which matches its average
+// mobility on an empty board (21.4 squares against 22.75).
+int bent_fraction(std::map<Direction, int> bent) {
+    return 150 * bent.size();
+}
+
+
 // Estimate piece value
 Value piece_value(Phase phase, PieceType pt)
 {
@@ -171,6 +180,8 @@ Value piece_value(Phase phase, PieceType pt)
             + (phase == MG ?  30 :  40) * pi->steps[0][MODALITY_QUIET].size()
             + (phase == MG ? 185 : 185) * slider_fraction(pi->slider[0][MODALITY_CAPTURE]) / 100
             + (phase == MG ?  55 :  45) * slider_fraction(pi->slider[0][MODALITY_QUIET]) / 100
+            + (phase == MG ? 185 : 185) * bent_fraction(pi->bent[0][MODALITY_CAPTURE]) / 100
+            + (phase == MG ?  55 :  45) * bent_fraction(pi->bent[0][MODALITY_QUIET]) / 100
             // Hoppers are more useful with more pieces on the board
             + (phase == MG ? 100 :  80) * pi->hopper[0][MODALITY_CAPTURE].size()
             + (phase == MG ?  85 :  60) * pi->hopper[0][MODALITY_QUIET].size()
@@ -226,7 +237,8 @@ void init(const Variant* v) {
       }
       
       const PieceInfo* pi = pieceMap.find(pt)->second;
-      bool isSlider = pi->slider[0][MODALITY_QUIET].size() || pi->slider[0][MODALITY_CAPTURE].size() || pi->hopper[0][MODALITY_QUIET].size() || pi->hopper[0][MODALITY_CAPTURE].size();
+      bool isSlider = pi->slider[0][MODALITY_QUIET].size() || pi->slider[0][MODALITY_CAPTURE].size() || pi->hopper[0][MODALITY_QUIET].size() || pi->hopper[0][MODALITY_CAPTURE].size()
+                   || pi->bent[0][MODALITY_QUIET].size() || pi->bent[0][MODALITY_CAPTURE].size();
       bool isPawn = !isSlider && pi->steps[0][MODALITY_QUIET].size() && !std::any_of(pi->steps[0][MODALITY_QUIET].begin(), pi->steps[0][MODALITY_QUIET].end(), [](const std::pair<const Direction, int>& d) { return d.first < SOUTH / 2; });
       bool isSlowLeaper = !isSlider && !std::any_of(pi->steps[0][MODALITY_QUIET].begin(), pi->steps[0][MODALITY_QUIET].end(), [](const std::pair<const Direction, int>& d) { return dist(d.first) > 1; });
 
@@ -238,7 +250,8 @@ void init(const Variant* v) {
           constexpr int r0 = rm + RANK_8;
           int r1 = rm + (v->maxRank + v->maxFile - 2 * v->capturesToHand) / 2;
           int leaper = pi->steps[0][MODALITY_QUIET].size() + pi->steps[0][MODALITY_CAPTURE].size();
-          int slider = pi->slider[0][MODALITY_QUIET].size() + pi->slider[0][MODALITY_CAPTURE].size() + pi->hopper[0][MODALITY_QUIET].size() + pi->hopper[0][MODALITY_CAPTURE].size();
+          int slider = pi->slider[0][MODALITY_QUIET].size() + pi->slider[0][MODALITY_CAPTURE].size() + pi->hopper[0][MODALITY_QUIET].size() + pi->hopper[0][MODALITY_CAPTURE].size()
+                     + bent_fraction(pi->bent[0][MODALITY_QUIET]) / 100 + bent_fraction(pi->bent[0][MODALITY_CAPTURE]) / 100;
           score = make_score(mg_value(score) * (lc * leaper + r1 * slider) / (lc * leaper + r0 * slider),
                              eg_value(score) * (lc * leaper + r1 * slider) / (lc * leaper + r0 * slider));
       }

--- a/src/types.h
+++ b/src/types.h
@@ -411,7 +411,7 @@ enum PieceType {
   SHOGI_PAWN, LANCE, SHOGI_KNIGHT, GOLD, DRAGON_HORSE,
   CLOBBER_PIECE, BREAKTHROUGH_PIECE, IMMOBILE_PIECE, CANNON, JANGGI_CANNON,
   SOLDIER, HORSE, ELEPHANT, JANGGI_ELEPHANT, BANNER,
-  WAZIR, COMMONER, CENTAUR,
+  WAZIR, COMMONER, CENTAUR, GRIFFON,
 
   CUSTOM_PIECE_1, CUSTOM_PIECE_2, CUSTOM_PIECE_3, CUSTOM_PIECE_4,
   CUSTOM_PIECE_5, CUSTOM_PIECE_6, CUSTOM_PIECE_7, CUSTOM_PIECE_8,
@@ -466,12 +466,24 @@ enum RiderType : int {
   RIDER_GRASSHOPPER_H = 1 << 11,
   RIDER_GRASSHOPPER_V = 1 << 12,
   RIDER_GRASSHOPPER_D = 1 << 13,
+  // Bent riders are not backed by a magic table: their relevant occupancy
+  // spans two files and two ranks, which would be prohibitive on 12x10.
+  // They are composed from the rook/bishop magics instead, see
+  // griffon_attacks_bb(). Keep them after all magic-backed riders, since
+  // rider_attacks_bb() indexes magics[] by the bit position.
+  RIDER_GRIFFON = 1 << 14,
+  MAGIC_RIDERS = RIDER_GRIFFON - 1,
+  BENT_RIDERS = RIDER_GRIFFON,
   HOPPING_RIDERS =  RIDER_CANNON_H | RIDER_CANNON_V | RIDER_CANNON_DIAG
                   | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D,
   LAME_LEAPERS = RIDER_LAME_DABBABA | RIDER_HORSE | RIDER_ELEPHANT | RIDER_JANGGI_ELEPHANT,
+  // Bent riders are asymmetrical: a Griffon on a1 reaches b5 via b2-b3-b4,
+  // while a Griffon on b5 reaches a1 via a4-a3-a2. Reachability is symmetric
+  // but the path is not, so attacks may not be derived from the target square.
   ASYMMETRICAL_RIDERS =  RIDER_HORSE | RIDER_JANGGI_ELEPHANT
-                       | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D,
-  NON_SLIDING_RIDERS = HOPPING_RIDERS | LAME_LEAPERS | RIDER_NIGHTRIDER,
+                       | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D
+                       | BENT_RIDERS,
+  NON_SLIDING_RIDERS = HOPPING_RIDERS | LAME_LEAPERS | RIDER_NIGHTRIDER | BENT_RIDERS,
 };
 
 extern Value PieceValue[PHASE_NB][PIECE_NB];

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -82,6 +82,7 @@
 # wazir (W)
 # commoner (K)
 # centaur (KN)
+# griffon (FyafsF)
 # king (K)
 
 ### Custom pieces
@@ -105,6 +106,8 @@
 # - limited and unlimited distance sliders/riders for W/R, F/B, and N directions
 # - hoppers and grasshoppers for W/R and F/B directions, i.e., pR, pB, gR, and gB
 # - lame leapers (n) for N, A, Z, and D directions, i.e., nN, nA, nZ, and nD
+# Bent riders, such as the griffon, are not expressible in the supported subset
+# and are only available as predefined piece types.
 
 ### Piece values
 # The predefined and precalculated piece values can be overridden
@@ -2124,3 +2127,12 @@ doubleStep = false
 pass = false
 bikjangRule = false
 materialCounting = none
+
+# Griffon chess
+# The griffon replaces the queen. It steps one square diagonally, may stop
+# there, and otherwise continues without limit in the orthogonal direction
+# leading away from its starting square, over empty squares only.
+[griffonchess:chess]
+griffon = g
+promotionPieceTypes = ngbrq
+startFen = rnbgkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBGKBNR w KQkq - 0 1


### PR DESCRIPTION
# Add the Griffon, a bent rider

Adds the Griffon as a predefined piece type: one diagonal step, on which it may
stop, then an unlimited orthogonal ride away from the starting square, over
empty squares only. Movement follows Jocly's `cbGriffonGraph` (a `cbSkiGraph`
over the four diagonal steps with a 45° bend, unlimited range, corner square
included as a destination).

Bent riders are currently not expressible in Fairy-Stockfish at all: `PieceInfo`
only has `steps`, `slider` and `hopper`, none of which can encode a change of
direction mid-move. This is the narrow version of the work @HGMuller did on the
`pieces` branch in #962 — Griffon only, no parser changes.

Refs #962, #966, #967.

## Why bent riders can't reuse the fast paths

Griffon reachability is symmetric (reachable iff both coordinate offsets are
non-zero and at least one is 1), but **the path is not**. A Griffon on a1
reaches b5 via b2-b3-b4; a Griffon on b5 reaches a1 via a4-a3-a2. The blocking
sets are disjoint.

That invalidates two assumptions: `checkSquares[pt]` is computed from the king
square and assumes reversibility, and `BetweenBB` is built as the intersection
of the two reciprocal attack sets, which for a1/b5 yields `{c2}` instead of the
real interposition squares `{a2, a3, a4}`.

Putting `RIDER_GRIFFON` in `NON_SLIDING_RIDERS` and `ASYMMETRICAL_RIDERS` is
enough to route around both, and no other correctness machinery was needed.
This matches what @HGMuller reported in #962: declaring the new rider types
non-sliding and asymmetrical was what made his king captures go away.

* `NON_SLIDING_RIDERS` makes `generate_all<EVASIONS>` fall back to
  `target = ~pos.pieces(Us)` and makes `legal()` skip its `between_bb`
  shortcut. The full `attackers_to()` at the end of `legal()` then covers pins.
* `ASYMMETRICAL_RIDERS` makes `slider_blockers()`, `attackers_to()` and
  `gives_check()` recompute attacks from each candidate square rather than
  reversing them.

## Changes

**types.h** — `GRIFFON` after `CENTAUR`. `RIDER_GRIFFON = 1 << 14`, placed after
every magic-backed rider, plus a `MAGIC_RIDERS` mask: `rider_attacks_bb`
indexes `magics[]` by bit position, so a rider bit without a magic table has to
be stripped before that loop.

**piece.h / piece.cpp** — a `bent[2][MOVE_MODALITY_NB]` map in `PieceInfo`,
keyed by the direction of the first leg, and `griffon_piece()` built like
`janggi_elephant_piece()`: `from_betza("F")` plus the four diagonal bent legs,
with `betza = "FyafsF"` for XBoard. Leaving the corner step in `steps` rather
than folding it into `bent` keeps "may the Griffon stop after one diagonal
step" a definition choice instead of hardcoding it.

**bitboard.h / bitboard.cpp** — no new magic table. Both continuation
directions of a diagonal leg are orthogonal, so one existing rook lookup per
corner square covers them, masked by a new `RayBB[8][SQUARE_NB]` (8 KB, 16 KB
with `LARGEBOARDS`) that discards the half pointing back at the origin. A
monolithic Griffon mask would span two files and two ranks, which looked
unwise on 12x10. `griffon_path_bb()` supplies the directed
`between_bb(s1, s2, GRIFFON)`.

**psqt.cpp** — `isSlider` and the board-size scaling only read `slider` and
`hopper`, so a piece whose movement lives in `bent` was silently classified as
a non-slider. Each bent leg is counted as 1.5 slider directions, putting the
Griffon at 2155 mg against 2590 for the queen (83%). Empty-board mobility is
21.4 squares against the queen's 22.75, and Jocly values them 8.3 vs 9.5 (87%),
so this is in the right region, but self-play tuning is the real answer.

**variants.ini** — documentation plus a `griffonchess` example variant.

## Testing

**No regression on standard chess.** `bench` gives 6180480 nodes both with and
without the patch. Perft from the start position to depth 6 = 119060324 and
Kiwipete to depth 5 = 193690690, both matching the known values.

**Move generation** cross-checked against an independent path-walking reference
over 400 random positions with friendly and enemy blockers, using `go perft 1`
on a variant whose blockers are `immobile` pieces so the move list contains only
Griffon moves: 0 disagreements.

**Check detection.** Two positions in `griffonchess`, same pieces, blocker moved
from b3 to a3:

| FEN | Expected | Result |
|---|---|---|
| `7k/8/8/1g6/8/1P6/8/K7 w - - 0 1` | check, 2 legal moves | `Checkers: b5`, perft 1 = 2 |
| `7k/8/8/1g6/8/P7/8/K7 w - - 0 1` | no check, 4 legal moves | no checkers, perft 1 = 4 |

A symmetric implementation gets both backwards. Worth keeping as a regression
test.

**Stress.** 108,759 plies of random games in `griffonchess` on a `debug=yes`
build (300 games, 67 reaching a terminal position), plus `go depth 22` on K+G vs
K endgames, which is where #962 crashed. No assertion failures. That is
consistent with those crashes having been the #966 bug fixed by #967.

**Perft, `griffonchess` start position:** 20, 400, 8682, 187940, 4437378. These
come from this implementation, so they are a reproducibility reference rather
than ground truth. Cross-checking them against the Interactive Diagram would be
worth more than anything I can produce here.

## Cost

Comparing like with like — both as user-defined variants, so both off the
`fastAttacks` path — `griffonchess` runs at 336 knps against 581 knps for the
same variant with a queen, about 40% slower. That is the asymmetrical and
non-sliding paths plus 8 magic lookups per attack query, and it only affects
variants that use the piece.

Custom piece headroom drops from 26 slots to 25. `customPiece25` still parses,
so nothing user-visible breaks.

## Limitations

* Predefined piece only. `bent` is not reachable from Betza, so `customPieceN`
  cannot produce a Griffon.
* Only the full set of four diagonal legs is supported; partial sets and range
  limits would need per piece type direction tables. There is an assert for it.
* `checkSquares` stays the approximate forward set, exactly as it already is for
  `HORSE`, which is also in `ASYMMETRICAL_RIDERS`. It only feeds `QUIET_CHECKS`
  generation, so the cost is a little search quality, not correctness.
* NNUE does not know the piece, so Griffon variants run on classical eval.

## Questions before this is worth polishing

1. Do you want this at all as a standalone piece, or would you rather upstream
   @HGMuller's `pieces` branch now that #967 has landed? That is a bigger but
   far more general change, and this PR should be dropped in its favour.
2. Should the XBoard notation match his branch exactly (`yafsF`, versus
   `FyafsF` here, since Jocly's Griffon can stop on the corner square)?
3. Is the ~40% slowdown acceptable, or would you want per-quadrant magics up
   front?
4. Extend the parser in this PR so `customPieceN` can express bent riders? It
   would also give the Rhino/Manticore almost for free — same code path,
   `BishopMagics` instead of the rook ones.
5. Should I replace the approximate `checkSquares` with a proper reverse
   computation, or is matching the existing `HORSE` treatment fine?

bench: 6180480