### PR TITLE
Bent riders: griffon, rhino, ship, snake, osprey

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -37,6 +37,9 @@ Bitboard PseudoMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard LeaperAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard LeaperMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 Bitboard BoardSizeBB[FILE_NB][RANK_NB];
+Bitboard RayBB[8][SQUARE_NB];
+BentRider BentAttacks[COLOR_NB][PIECE_TYPE_NB];
+BentRider BentMoves[2][COLOR_NB][PIECE_TYPE_NB];
 RiderType AttackRiderTypes[PIECE_TYPE_NB];
 RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
 
@@ -186,7 +189,21 @@ namespace {
     return b;
   }
 
-  Bitboard lame_leaper_attack(std::map<Direction, int> directions, Square s, Bitboard occupied) {
+  void init_rays() {
+
+  for (int i = 0; i < 8; ++i)
+      for (Square s = SQ_A1; s <= SQ_MAX; ++s)
+      {
+          Bitboard b = 0;
+          for (Square t = s + QueenDirections[i];
+               is_ok(t) && distance(t, t - QueenDirections[i]) == 1;
+               t += QueenDirections[i])
+              b |= t;
+          RayBB[i][s] = b;
+      }
+}
+
+Bitboard lame_leaper_attack(std::map<Direction, int> directions, Square s, Bitboard occupied) {
     Bitboard b = 0;
     for (const auto& i : directions)
     {
@@ -198,6 +215,52 @@ namespace {
   }
 
 }
+
+/// bent_path_bb() returns the squares a bent rider of type 'pt' standing on
+/// 'from' has to pass through to reach 'to', excluding both end points, or 0
+/// if 'to' is out of reach or is reached by the plain step onto the corner.
+/// Unlike a straight slider, the path depends on which end the piece starts
+/// from: a Griffon on a1 reaches b5 through b2-b3-b4, while a Griffon on b5
+/// reaches a1 through a4-a3-a2. Colour is not available here, and matters
+/// only for bent riders whose legs are not centrally symmetric, so both are
+/// tried; a miss costs a pin that goes undetected, never a legality error,
+/// since bent riders are in NON_SLIDING_RIDERS and legal() recomputes.
+
+Bitboard bent_path_bb(PieceType pt, Square from, Square to) {
+
+  assert(is_ok(from) && is_ok(to));
+
+  for (Color c : { WHITE, BLACK })
+  {
+      const BentRider& br = BentAttacks[c][pt];
+      for (int k = 0; k < br.count; k++)
+      {
+          int i = br.dir[k];
+          Square corner = Square(from + QueenDirections[i]);
+          if (!is_ok(corner) || distance(from, corner) != 1)
+              continue;
+          if (corner == to)
+              return 0; // reached by the plain step, nothing in between
+          for (int j = 0; j < 2; j++)
+          {
+              if (!(br.cont[k] & (1 << j)))
+                  continue;
+              Direction d = QueenDirections[(i + (j ? 7 : 1)) & 7];
+              Bitboard b = square_bb(corner);
+              for (Square s = Square(corner + d);
+                   is_ok(s) && distance(s, s - d) == 1;
+                   s += d)
+              {
+                  if (s == to)
+                      return b;
+                  b |= s;
+              }
+          }
+      }
+  }
+  return 0;
+}
+
 
 /// safe_destination() returns the bitboard of target square for the given step
 /// from the given square. If the step is off the board, returns empty bitboard.
@@ -276,6 +339,33 @@ void Bitboards::init_pieces() {
                   if (BishopDirections.find(d) != BishopDirections.end())
                       riderTypes |= limit == 1 ? RIDER_GRASSHOPPER_D : RIDER_CANNON_DIAG;
               }
+              // Bent riders. One rider bit covers every shape; the shape
+              // itself is flattened into BentAttacks/BentMoves, mirrored for
+              // black by turning each leg through 180 degrees, which is a
+              // half turn around the QueenDirections table and leaves the
+              // continuation mask unchanged.
+              if (!pi->bent[initial][modality].empty())
+              {
+                  riderTypes |= RIDER_BENT;
+                  for (Color c : { WHITE, BLACK })
+                  {
+                      BentRider& br = modality == MODALITY_CAPTURE ? BentAttacks[c][pt]
+                                                                   : BentMoves[initial][c][pt];
+                      br.count = 0;
+                      for (auto const& [d, mask] : pi->bent[initial][modality])
+                      {
+                          int i = -1;
+                          for (int k = 0; k < 8; k++)
+                              if (QueenDirections[k] == (c == WHITE ? d : -d))
+                                  i = k;
+                          if (i < 0 || br.count >= 8)
+                              continue;
+                          br.dir[br.count] = i;
+                          br.cont[br.count] = mask;
+                          br.count++;
+                      }
+                  }
+              }
           }
       }
 
@@ -303,6 +393,9 @@ void Bitboards::init_pieces() {
                       }
                       pseudo |= sliding_attack<RIDER>(pi->slider[initial][modality], s, 0, c);
                       pseudo |= sliding_attack<HOPPER_RANGE>(pi->hopper[initial][modality], s, 0, c);
+                      if (!pi->bent[initial][modality].empty())
+                          pseudo |= bent_attacks_bb(modality == MODALITY_CAPTURE ? BentAttacks[c][pt]
+                                                                                 : BentMoves[initial][c][pt], s, 0);
                   }
               }
           }
@@ -361,6 +454,8 @@ void Bitboards::init() {
   init_magics<HOPPER>(GrasshopperTableV, GrasshopperMagicsV, GrasshopperDirectionsV);
   init_magics<HOPPER>(GrasshopperTableD, GrasshopperMagicsD, GrasshopperDirectionsD);
 #endif
+
+  init_rays();
 
   init_pieces();
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -236,11 +236,13 @@ Bitboard bent_path_bb(PieceType pt, Square from, Square to) {
       for (int k = 0; k < br.count; k++)
       {
           int i = br.dir[k];
-          Square corner = Square(from + QueenDirections[i]);
-          if (!is_ok(corner) || distance(from, corner) != 1)
+          Square corner = Square(from + br.len[k] * QueenDirections[i]);
+          if (!is_ok(corner) || distance(from, corner) != br.len[k])
               continue;
           if (corner == to)
-              return 0; // reached by the plain step, nothing in between
+              return 0; // reached by the leg alone, nothing in between
+          // A leg of more than one square is jumped, so it contributes no
+          // blocking squares - only the ride does.
           for (int j = 0; j < 2; j++)
           {
               if (!(br.cont[k] & (1 << j)))
@@ -352,16 +354,23 @@ void Bitboards::init_pieces() {
                       BentRider& br = modality == MODALITY_CAPTURE ? BentAttacks[c][pt]
                                                                    : BentMoves[initial][c][pt];
                       br.count = 0;
-                      for (auto const& [d, mask] : pi->bent[initial][modality])
+                      for (auto const& [d, shape] : pi->bent[initial][modality])
                       {
+                          // The parser packs the leg length above the two
+                          // continuation bits, and the key is the whole leg
+                          // vector, so dividing it by the length recovers the
+                          // direction the leg points in.
+                          int len = shape >> 2;
+                          Direction leg = c == WHITE ? d : -d;
                           int i = -1;
-                          for (int k = 0; k < 8; k++)
-                              if (QueenDirections[k] == (c == WHITE ? d : -d))
+                          for (int k = 0; len && k < 8; k++)
+                              if (QueenDirections[k] == Direction(leg / len))
                                   i = k;
                           if (i < 0 || br.count >= 8)
                               continue;
                           br.dir[br.count] = i;
-                          br.cont[br.count] = mask;
+                          br.len[br.count] = len;
+                          br.cont[br.count] = shape & 3;
                           br.count++;
                       }
                   }

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -178,7 +178,8 @@ extern Bitboard RayBB[8][SQUARE_NB];
 
 struct BentRider {
   int count = 0;
-  int dir[8] = {};
+  int dir[8] = {};   // index into QueenDirections
+  int len[8] = {};   // squares covered by the first leg, jumped over if > 1
   int cont[8] = {};
 };
 
@@ -491,11 +492,11 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
   }
 }
 
-/// bent_attacks_bb() returns the riding part of a bent rider: one step onto a
+/// bent_attacks_bb() returns the riding part of a bent rider: one leg onto a
 /// corner square, which has to be empty for the move to continue, then an
-/// unlimited ride 45 degrees off that step, away from the origin. The corner
-/// square itself is not included here, it is covered by the ordinary step the
-/// parser records alongside every bent leg.
+/// unlimited ride 45 degrees off that leg, away from the origin. The corner
+/// square itself is not included here, it is covered by the ordinary step or
+/// leap the parser records alongside every bent leg.
 /// Both continuations of a diagonal leg are orthogonal and both continuations
 /// of an orthogonal leg are diagonal, so one rook or bishop lookup covers a
 /// whole corner; RayBB then discards everything pointing back at the origin.
@@ -506,8 +507,11 @@ inline Bitboard bent_attacks_bb(const BentRider& br, Square s, Bitboard occupied
   for (int k = 0; k < br.count; k++)
   {
       int i = br.dir[k];
-      Square t = Square(s + QueenDirections[i]);
-      if (!is_ok(t) || distance(s, t) != 1 || (occupied & t))
+      // A first leg of more than one square is a leap: only where it lands
+      // matters, never what it passes over. distance() catches the wrap of a
+      // leg that ran off the side of the board.
+      Square t = Square(s + br.len[k] * QueenDirections[i]);
+      if (!is_ok(t) || distance(s, t) != br.len[k] || (occupied & t))
           continue;
       Bitboard rays = 0;
       if (br.cont[k] & 1)

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -161,6 +161,32 @@ extern Magic GrasshopperMagicsD[SQUARE_NB];
 
 extern Magic* magics[];
 
+// The eight queen directions, in rotational order: rotating by 45 degrees is
+// a +/-1 step in this array. Diagonals sit at the odd indices.
+constexpr Direction QueenDirections[8] = { NORTH, NORTH_EAST, EAST, SOUTH_EAST,
+                                           SOUTH, SOUTH_WEST, WEST, NORTH_WEST };
+
+// RayBB[d][s] holds every square from s to the board edge in direction
+// QueenDirections[d], excluding s. Used to keep only the half of a rook attack
+// set that points away from a bent rider's origin square.
+extern Bitboard RayBB[8][SQUARE_NB];
+
+/// BentRider is a bent rider's shape, flattened out of PieceInfo::bent so that
+/// the attack path needs no map lookup: for each first leg, the index of its
+/// direction in QueenDirections, and the mask of continuations it takes
+/// (1 for 45 degrees clockwise, 2 for counter-clockwise, 3 for both).
+
+struct BentRider {
+  int count = 0;
+  int dir[8] = {};
+  int cont[8] = {};
+};
+
+extern BentRider BentAttacks[COLOR_NB][PIECE_TYPE_NB];
+extern BentRider BentMoves[2][COLOR_NB][PIECE_TYPE_NB];
+
+Bitboard bent_path_bb(PieceType pt, Square from, Square to);
+
 constexpr Bitboard make_bitboard() { return 0; }
 
 template<typename ...Squares>
@@ -326,6 +352,10 @@ inline Bitboard between_bb(Square s1, Square s2, PieceType pt) {
   else if (pt == JANGGI_ELEPHANT)
       return  (PseudoAttacks[WHITE][WAZIR][s2] & PseudoAttacks[WHITE][ALFIL][s1])
             | (PseudoAttacks[WHITE][KNIGHT][s2] & PseudoAttacks[WHITE][FERS][s1]);
+  else if (AttackRiderTypes[pt] & BENT_RIDERS)
+      // The path of a bent rider depends on which end it starts from, so it
+      // has to be traced from the piece (s2) towards the target (s1).
+      return bent_path_bb(pt, s2, s1);
   else
       return between_bb(s1, s2);
 }
@@ -461,6 +491,35 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
   }
 }
 
+/// bent_attacks_bb() returns the riding part of a bent rider: one step onto a
+/// corner square, which has to be empty for the move to continue, then an
+/// unlimited ride 45 degrees off that step, away from the origin. The corner
+/// square itself is not included here, it is covered by the ordinary step the
+/// parser records alongside every bent leg.
+/// Both continuations of a diagonal leg are orthogonal and both continuations
+/// of an orthogonal leg are diagonal, so one rook or bishop lookup covers a
+/// whole corner; RayBB then discards everything pointing back at the origin.
+
+inline Bitboard bent_attacks_bb(const BentRider& br, Square s, Bitboard occupied) {
+
+  Bitboard b = 0;
+  for (int k = 0; k < br.count; k++)
+  {
+      int i = br.dir[k];
+      Square t = Square(s + QueenDirections[i]);
+      if (!is_ok(t) || distance(s, t) != 1 || (occupied & t))
+          continue;
+      Bitboard rays = 0;
+      if (br.cont[k] & 1)
+          rays |= RayBB[(i + 1) & 7][t];
+      if (br.cont[k] & 2)
+          rays |= RayBB[(i + 7) & 7][t];
+      b |= ((i & 1) ? attacks_bb<ROOK>(t, occupied) : attacks_bb<BISHOP>(t, occupied)) & rays;
+  }
+  return b;
+}
+
+
 /// pop_rider() finds and clears a rider in a (hybrid) rider type
 
 inline RiderType pop_rider(RiderType* r) {
@@ -473,6 +532,9 @@ inline RiderType pop_rider(RiderType* r) {
 inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   Bitboard b = LeaperAttacks[c][pt][s];
   RiderType r = AttackRiderTypes[pt];
+  if (r & RIDER_BENT)
+      b |= bent_attacks_bb(BentAttacks[c][pt], s, occupied);
+  r &= MAGIC_RIDERS;
   while (r)
       b |= rider_attacks_bb(pop_rider(&r), s, occupied);
   return b & PseudoAttacks[c][pt][s];
@@ -483,6 +545,9 @@ template <bool Initial=false>
 inline Bitboard moves_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   Bitboard b = LeaperMoves[Initial][c][pt][s];
   RiderType r = MoveRiderTypes[Initial][pt];
+  if (r & RIDER_BENT)
+      b |= bent_attacks_bb(BentMoves[Initial][c][pt], s, occupied);
+  r &= MAGIC_RIDERS;
   while (r)
       b |= rider_attacks_bb(pop_rider(&r), s, occupied);
   return b & PseudoMoves[Initial][c][pt][s];

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -432,6 +432,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("enPassantRegionBlack", v->enPassantRegion[BLACK]);
     parse_attribute("enPassantTypes", v->enPassantTypes[WHITE], v->pieceToChar);
     parse_attribute("enPassantTypes", v->enPassantTypes[BLACK], v->pieceToChar);
+    parse_attribute("enPassantTargetTypes", v->enPassantTargetTypes, v->pieceToChar);
     parse_attribute("enPassantTypesWhite", v->enPassantTypes[WHITE], v->pieceToChar);
     parse_attribute("enPassantTypesBlack", v->enPassantTypes[BLACK], v->pieceToChar);
     parse_attribute("castling", v->castling);

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -50,6 +50,38 @@ namespace {
   };
   const std::string verticals = "fbvh";
   const std::string horizontals = "rlsh";
+  // The eight queen directions in rotational order, as (file, rank) offsets:
+  // one step along this table is a 45 degree turn. Must stay in the same order
+  // as QueenDirections in bitboard.h, which indexes RayBB the same way.
+  constexpr int BentRotation[8][2] = { {0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}, {-1,0}, {-1,1} };
+
+  int bent_direction_index(int df, int dr) {
+      for (int i = 0; i < 8; i++)
+          if (BentRotation[i][0] == df && BentRotation[i][1] == dr)
+              return i;
+      return -1;
+  }
+
+  // Which of the two continuations of a bent leg survive the filter. Bit 1 is
+  // the direction 45 degrees clockwise from the leg, bit 2 the one 45 degrees
+  // counter-clockwise; filter 0 keeps both, 1 keeps only continuations running
+  // along a file, 2 only those running along a rank. Returns 0 for legs longer
+  // than a single step, which is what neutralizes a nonsensical y on a rider.
+  int continuation_mask(int df, int dr, int filter) {
+      int i = bent_direction_index(df, dr);
+      if (i < 0)
+          return 0;
+      int mask = 0;
+      for (int k = 0; k < 2; k++)
+      {
+          const int* cont = BentRotation[(i + (k ? 7 : 1)) & 7];
+          if (   filter == 0
+              || (filter == 1 && cont[0] == 0)
+              || (filter == 2 && cont[1] == 0))
+              mask |= 1 << k;
+      }
+      return mask;
+  }
   // from_betza creates a piece by parsing Betza notation
   // https://en.wikipedia.org/wiki/Betza%27s_funny_notation
   PieceInfo* from_betza(const std::string& betza, const std::string& name) {
@@ -61,6 +93,8 @@ namespace {
       bool rider = false;
       bool lame = false;
       bool initial = false;
+      bool bent = false;
+      int contFilter = 0;
       int distance = 0;
       std::vector<std::string> prelimDirections = {};
       for (std::string::size_type i = 0; i < betza.size(); i++)
@@ -80,6 +114,24 @@ namespace {
           // Lame leaper
           else if (c == 'n')
               lame = true;
+          // Bent rider: the atom gives the first leg, on which the piece may
+          // stop, and the ride then continues without limit 45 degrees off it.
+          else if (c == 'y')
+          {
+              bent = true;
+              // Accept the "afs" spelling XBoard/Winboard uses for the second
+              // leg, so that a piece written yafsF there parses unchanged here.
+              if (betza.compare(i + 1, 3, "afs") == 0)
+                  i += 3;
+              // A single v or h straight after the y restricts the ride to the
+              // continuations running along a file, or along a rank. That is
+              // what separates the Ship (yvF) from the Griffon (yF).
+              // Directional modifiers written *before* the y keep their usual
+              // meaning and restrict the first leg instead, hence vyW for the
+              // Snake against yW for the Rhino.
+              else if (i + 1 < betza.size() && (betza[i+1] == 'v' || betza[i+1] == 'h'))
+                  contFilter = betza[++i] == 'v' ? 1 : 2;
+          }
           // Initial move
           else if (c == 'i')
               initial = true;
@@ -148,22 +200,37 @@ namespace {
                       auto has_dir = [&](std::string s) {
                         return std::find(directions.begin(), directions.end(), s) != directions.end();
                       };
+                      // Records one direction as an ordinary move and, for a
+                      // bent rider, as a bent leg as well, carrying the mask of
+                      // the continuations that survived the yv/yh filter. The
+                      // ordinary move is what lets the piece stop on the corner
+                      // square, which is how every bent rider in use behaves.
+                      auto add_dir = [&](int df, int dr) {
+                          Direction d = Direction(dr * FILE_NB + df);
+                          v[d] = distance;
+                          if (bent && !rider && !hopper)
+                          {
+                              int mask = continuation_mask(df, dr, contFilter);
+                              if (mask)
+                                  p->bent[initial][modality][d] = mask;
+                          }
+                      };
                       if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("rf") || has_dir("rv") || has_dir("fh") || has_dir("rh") || has_dir("hr"))
-                          v[Direction(atom.first * FILE_NB + atom.second)] = distance;
+                          add_dir(atom.second, atom.first);
                       if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("lb") || has_dir("lv") || has_dir("bh") || has_dir("lh") || has_dir("hr"))
-                          v[Direction(-atom.first * FILE_NB - atom.second)] = distance;
+                          add_dir(-atom.second, -atom.first);
                       if (directions.size() == 0 || has_dir("rr") || has_dir("ss") || has_dir("br") || has_dir("bs") || has_dir("bh") || has_dir("rh") || has_dir("hr"))
-                          v[Direction(-atom.second * FILE_NB + atom.first)] = distance;
+                          add_dir(atom.first, -atom.second);
                       if (directions.size() == 0 || has_dir("ll") || has_dir("ss") || has_dir("fl") || has_dir("fs") || has_dir("fh") || has_dir("lh") || has_dir("hr"))
-                          v[Direction(atom.second * FILE_NB - atom.first)] = distance;
+                          add_dir(-atom.first, atom.second);
                       if (directions.size() == 0 || has_dir("rr") || has_dir("ss") || has_dir("fr") || has_dir("fs") || has_dir("fh") || has_dir("rh") || has_dir("hl"))
-                          v[Direction(atom.second * FILE_NB + atom.first)] = distance;
+                          add_dir(atom.first, atom.second);
                       if (directions.size() == 0 || has_dir("ll") || has_dir("ss") || has_dir("bl") || has_dir("bs") || has_dir("bh") || has_dir("lh") || has_dir("hl"))
-                          v[Direction(-atom.second * FILE_NB - atom.first)] = distance;
+                          add_dir(-atom.first, -atom.second);
                       if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("rb") || has_dir("rv") || has_dir("bh") || has_dir("rh") || has_dir("hl"))
-                          v[Direction(-atom.first * FILE_NB + atom.second)] = distance;
+                          add_dir(atom.second, -atom.first);
                       if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("lf") || has_dir("lv") || has_dir("fh") || has_dir("lh") || has_dir("hl"))
-                          v[Direction(atom.first * FILE_NB - atom.second)] = distance;
+                          add_dir(-atom.second, atom.first);
                   }
               }
               // Reset state
@@ -173,6 +240,8 @@ namespace {
               rider = false;
               lame = false;
               initial = false;
+              bent = false;
+              contFilter = 0;
               distance = 0;
           }
       }

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -62,13 +62,28 @@ namespace {
       return -1;
   }
 
+  // Splits a bent rider's first leg into a direction and a length, so that a
+  // leg of more than one square is turned as easily as a step: the osprey
+  // leaps two squares orthogonally (yD) before riding out diagonally, and
+  // turning that leap by 45 degrees is turning the direction it points in.
+  // Returns -1 for a leg that is not a multiple of a queen direction, a
+  // knight's for instance, where a 45 degree turn means nothing.
+  int bent_leg(int df, int dr, int* length) {
+      int len = std::max(std::abs(df), std::abs(dr));
+      if (!len || (df && dr && std::abs(df) != std::abs(dr)))
+          return -1;
+      *length = len;
+      return bent_direction_index(df / len, dr / len);
+  }
+
   // Which of the two continuations of a bent leg survive the filter. Bit 1 is
   // the direction 45 degrees clockwise from the leg, bit 2 the one 45 degrees
   // counter-clockwise; filter 0 keeps both, 1 keeps only continuations running
-  // along a file, 2 only those running along a rank. Returns 0 for legs longer
-  // than a single step, which is what neutralizes a nonsensical y on a rider.
+  // along a file, 2 only those running along a rank. The leg length is packed
+  // above them, so that one int carries the whole shape of the leg.
   int continuation_mask(int df, int dr, int filter) {
-      int i = bent_direction_index(df, dr);
+      int len = 0;
+      int i = bent_leg(df, dr, &len);
       if (i < 0)
           return 0;
       int mask = 0;
@@ -80,7 +95,7 @@ namespace {
               || (filter == 2 && cont[1] == 0))
               mask |= 1 << k;
       }
-      return mask;
+      return mask ? (mask | (len << 2)) : 0;
   }
   // from_betza creates a piece by parsing Betza notation
   // https://en.wikipedia.org/wiki/Betza%27s_funny_notation

--- a/src/piece.h
+++ b/src/piece.h
@@ -37,6 +37,16 @@ struct PieceInfo {
   std::map<Direction, int> steps[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> slider[2][MOVE_MODALITY_NB] = {};
   std::map<Direction, int> hopper[2][MOVE_MODALITY_NB] = {};
+  // Bent riders. The key is the direction of the *first* leg. The value is a
+  // mask of which continuations are taken: 1 for the direction 45 degrees
+  // clockwise from the first leg, 2 for 45 degrees counter-clockwise, 3 for
+  // both. So {NE:3, SE:3, SW:3, NW:3} is a Griffon, {N:3, E:3, S:3, W:3} a
+  // Rhino, {N:3, S:3} the half-Rhino known as the Snake, and the four
+  // diagonals each keeping only their file-parallel continuation the
+  // half-Griffon known as the Ship.
+  // The corner square is not a destination here; the parser records it as an
+  // ordinary step alongside, so a Griffon is "F" plus the four bent legs.
+  std::map<Direction, int> bent[2][MOVE_MODALITY_NB] = {};
 };
 
 struct PieceMap : public std::map<PieceType, const PieceInfo*> {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1930,9 +1930,14 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       // Update material
       st->nonPawnMaterial[us] += PieceValue[MG][demotion] - PieceValue[MG][pc];
   }
-  // Set en passant square(s) if the moved piece can be captured
+  // Set en passant square(s) if the moved piece can be captured, either
+  // because the destination is one only its initial move set could reach, or
+  // because the piece is declared an en passant target and moved more than one
+  // square - the latter covers pieces that keep a multi-square step all game,
+  // such as the prince of Timurid.
   else if (   type_of(m) != DROP
-           && ((PseudoMoves[1][us][type_of(pc)][from] & ~PseudoMoves[0][us][type_of(pc)][from]) & to))
+           && (   ((PseudoMoves[1][us][type_of(pc)][from] & ~PseudoMoves[0][us][type_of(pc)][from]) & to)
+               || ((var->enPassantTargetTypes & type_of(pc)) && distance(from, to) > 1)))
   {
       assert(type_of(pc) != PAWN);
       st->epSquares = between_bb(from, to) & var->enPassantRegion[them];

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -171,8 +171,8 @@ int slider_fraction(std::map<Direction, int> slider) {
 // Ship, Snake - correctly valued at about half of the full piece.
 int bent_fraction(std::map<Direction, int> bent) {
     int s = 0;
-    for (auto const& [_, mask] : bent)
-        s += 75 * ((mask & 1) + ((mask >> 1) & 1));
+    for (auto const& [_, shape] : bent)
+        s += 75 * ((shape & 1) + ((shape >> 1) & 1));
     return s;
 }
 

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -163,6 +163,20 @@ int slider_fraction(std::map<Direction, int> slider) {
 }
 
 
+// Bent rays are shorter on average than straight ones, so each continuation
+// counts as three quarters of a slider direction. On 8x8 that puts the Griffon
+// (four legs, both continuations) slightly below the queen, matching its
+// average mobility on an empty board: 21.4 squares against 22.75. Weighting by
+// the continuation mask rather than by leg count keeps the half-versions -
+// Ship, Snake - correctly valued at about half of the full piece.
+int bent_fraction(std::map<Direction, int> bent) {
+    int s = 0;
+    for (auto const& [_, mask] : bent)
+        s += 75 * ((mask & 1) + ((mask >> 1) & 1));
+    return s;
+}
+
+
 // Estimate piece value
 Value piece_value(Phase phase, PieceType pt)
 {
@@ -171,6 +185,8 @@ Value piece_value(Phase phase, PieceType pt)
             + (phase == MG ?  30 :  40) * pi->steps[0][MODALITY_QUIET].size()
             + (phase == MG ? 185 : 185) * slider_fraction(pi->slider[0][MODALITY_CAPTURE]) / 100
             + (phase == MG ?  55 :  45) * slider_fraction(pi->slider[0][MODALITY_QUIET]) / 100
+            + (phase == MG ? 185 : 185) * bent_fraction(pi->bent[0][MODALITY_CAPTURE]) / 100
+            + (phase == MG ?  55 :  45) * bent_fraction(pi->bent[0][MODALITY_QUIET]) / 100
             // Hoppers are more useful with more pieces on the board
             + (phase == MG ? 100 :  80) * pi->hopper[0][MODALITY_CAPTURE].size()
             + (phase == MG ?  85 :  60) * pi->hopper[0][MODALITY_QUIET].size()
@@ -226,7 +242,8 @@ void init(const Variant* v) {
       }
       
       const PieceInfo* pi = pieceMap.find(pt)->second;
-      bool isSlider = pi->slider[0][MODALITY_QUIET].size() || pi->slider[0][MODALITY_CAPTURE].size() || pi->hopper[0][MODALITY_QUIET].size() || pi->hopper[0][MODALITY_CAPTURE].size();
+      bool isSlider = pi->slider[0][MODALITY_QUIET].size() || pi->slider[0][MODALITY_CAPTURE].size() || pi->hopper[0][MODALITY_QUIET].size() || pi->hopper[0][MODALITY_CAPTURE].size()
+                   || pi->bent[0][MODALITY_QUIET].size() || pi->bent[0][MODALITY_CAPTURE].size();
       bool isPawn = !isSlider && pi->steps[0][MODALITY_QUIET].size() && !std::any_of(pi->steps[0][MODALITY_QUIET].begin(), pi->steps[0][MODALITY_QUIET].end(), [](const std::pair<const Direction, int>& d) { return d.first < SOUTH / 2; });
       bool isSlowLeaper = !isSlider && !std::any_of(pi->steps[0][MODALITY_QUIET].begin(), pi->steps[0][MODALITY_QUIET].end(), [](const std::pair<const Direction, int>& d) { return dist(d.first) > 1; });
 
@@ -238,7 +255,8 @@ void init(const Variant* v) {
           constexpr int r0 = rm + RANK_8;
           int r1 = rm + (v->maxRank + v->maxFile - 2 * v->capturesToHand) / 2;
           int leaper = pi->steps[0][MODALITY_QUIET].size() + pi->steps[0][MODALITY_CAPTURE].size();
-          int slider = pi->slider[0][MODALITY_QUIET].size() + pi->slider[0][MODALITY_CAPTURE].size() + pi->hopper[0][MODALITY_QUIET].size() + pi->hopper[0][MODALITY_CAPTURE].size();
+          int slider = pi->slider[0][MODALITY_QUIET].size() + pi->slider[0][MODALITY_CAPTURE].size() + pi->hopper[0][MODALITY_QUIET].size() + pi->hopper[0][MODALITY_CAPTURE].size()
+                     + bent_fraction(pi->bent[0][MODALITY_QUIET]) / 100 + bent_fraction(pi->bent[0][MODALITY_CAPTURE]) / 100;
           score = make_score(mg_value(score) * (lc * leaper + r1 * slider) / (lc * leaper + r0 * slider),
                              eg_value(score) * (lc * leaper + r1 * slider) / (lc * leaper + r0 * slider));
       }

--- a/src/types.h
+++ b/src/types.h
@@ -466,12 +466,29 @@ enum RiderType : int {
   RIDER_GRASSHOPPER_H = 1 << 11,
   RIDER_GRASSHOPPER_V = 1 << 12,
   RIDER_GRASSHOPPER_D = 1 << 13,
+  // Bent riders take one step, then ride away without limit in one or both
+  // of the directions 45 degrees off that step (Griffon, Rhino, and the
+  // half-versions of either). They are not backed by a magic table: their
+  // relevant occupancy spans two files and two ranks, which would be
+  // prohibitive on 12x10, so they are composed from the rook/bishop magics
+  // instead, see bent_attacks_bb(). One bit is enough for all of them - the
+  // per piece type shape lives in BentAttacks/BentMoves. Keep the bit after
+  // every magic-backed rider, since rider_attacks_bb() indexes magics[] by
+  // bit position.
+  RIDER_BENT = 1 << 14,
+  MAGIC_RIDERS = RIDER_BENT - 1,
+  BENT_RIDERS = RIDER_BENT,
   HOPPING_RIDERS =  RIDER_CANNON_H | RIDER_CANNON_V | RIDER_CANNON_DIAG
                   | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D,
   LAME_LEAPERS = RIDER_LAME_DABBABA | RIDER_HORSE | RIDER_ELEPHANT | RIDER_JANGGI_ELEPHANT,
+  // Bent riders are asymmetrical: a Griffon on a1 reaches b5 via b2-b3-b4,
+  // while a Griffon on b5 reaches a1 via a4-a3-a2. Reachability is symmetric
+  // but the path is not, so attacks may not be derived from the target
+  // square. For the half-versions not even reachability is symmetric.
   ASYMMETRICAL_RIDERS =  RIDER_HORSE | RIDER_JANGGI_ELEPHANT
-                       | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D,
-  NON_SLIDING_RIDERS = HOPPING_RIDERS | LAME_LEAPERS | RIDER_NIGHTRIDER,
+                       | RIDER_GRASSHOPPER_H | RIDER_GRASSHOPPER_V | RIDER_GRASSHOPPER_D
+                       | BENT_RIDERS,
+  NON_SLIDING_RIDERS = HOPPING_RIDERS | LAME_LEAPERS | RIDER_NIGHTRIDER | BENT_RIDERS,
 };
 
 extern Value PieceValue[PHASE_NB][PIECE_NB];

--- a/src/variant.h
+++ b/src/variant.h
@@ -73,6 +73,11 @@ struct Variant {
   Bitboard tripleStepRegion[COLOR_NB] = {};
   Bitboard enPassantRegion[COLOR_NB] = {AllSquares, AllSquares};
   PieceSet enPassantTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
+  // Non-pawn pieces that leave en passant squares behind them on any move of
+  // more than one square. Without this, a non-pawn is only capturable en
+  // passant on a move that its *initial* move set alone can make, which does
+  // not cover pieces whose multi-square step stays available all game.
+  PieceSet enPassantTargetTypes = NO_PIECE_SET;
   bool castling = true;
   bool castlingDroppedPiece = false;
   File castlingKingsideFile = FILE_G;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -105,6 +105,14 @@
 # - limited and unlimited distance sliders/riders for W/R, F/B, and N directions
 # - hoppers and grasshoppers for W/R and F/B directions, i.e., pR, pB, gR, and gB
 # - lame leapers (n) for N, A, Z, and D directions, i.e., nN, nA, nZ, and nD
+# - bent riders (y): one step onto the atom's square, on which the piece may
+#   stop, then an unlimited ride 45 degrees off that step, away from the
+#   starting square, over empty squares only. yF is the griffon and yW the
+#   rhino. Directional modifiers written before the y restrict the first leg,
+#   so vyW is the snake (a rhino that only steps along a file first). A single
+#   v or h written straight after the y restricts the ride instead, so yvF is
+#   the ship (a griffon whose ride only runs along a file). The XBoard
+#   spelling yafsF is accepted as an alias of yF.
 
 ### Piece values
 # The predefined and precalculated piece values can be overridden
@@ -195,6 +203,10 @@
 # enPassantRegion: define region (target squares) where en passant is allowed after double steps [Bitboard] (default: AllSquares)
 # enPassantRegionWhite: define region (target squares) where en passant is allowed for white [Bitboard] (default: AllSquares)
 # enPassantRegionBlack: define region (target squares) where en passant is allowed for black [Bitboard] (default: AllSquares)
+# enPassantTargetTypes: non-pawn pieces that can be captured en passant after
+#                       any move of more than one square [PieceSet] (default: )
+#                       Without this a non-pawn only leaves en passant squares
+#                       on a move that only its initial move set can make.
 # enPassantTypes: define pieces able to capture en passant [PieceSet] (default: p)
 # enPassantTypesWhite: define white pieces able to capture en passant [PieceSet] (default: p)
 # enPassantTypesBlack: define black pieces able to capture en passant [PieceSet] (default: p)
@@ -2124,3 +2136,12 @@ doubleStep = false
 pass = false
 bikjangRule = false
 materialCounting = none
+
+# Griffon chess
+# The griffon replaces the queen. It steps one square diagonally, may stop
+# there, and otherwise continues without limit in the orthogonal direction
+# leading away from its starting square, over empty squares only.
+[griffonchess:chess]
+customPiece1 = g:yF
+promotionPieceTypes = ngbrq
+startFen = rnbgkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBGKBNR w KQkq - 0 1

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -113,6 +113,9 @@
 #   v or h written straight after the y restricts the ride instead, so yvF is
 #   the ship (a griffon whose ride only runs along a file). The XBoard
 #   spelling yafsF is accepted as an alias of yF.
+#   The first leg may be longer than a step, in which case it is a leap and
+#   what it passes over is irrelevant: yD is the osprey, which jumps two
+#   squares orthogonally and then rides out diagonally.
 
 ### Piece values
 # The predefined and precalculated piece values can be overridden
@@ -2145,3 +2148,12 @@ materialCounting = none
 customPiece1 = g:yF
 promotionPieceTypes = ngbrq
 startFen = rnbgkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBGKBNR w KQkq - 0 1
+
+# Osprey chess
+# The osprey replaces the queen. It leaps two squares orthogonally, jumping
+# whatever stands in between, may stop there, and otherwise continues without
+# limit along the diagonal leading away from its starting square.
+[ospreychess:chess]
+customPiece1 = o:yD
+promotionPieceTypes = nobr
+startFen = rnbokbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBOKBNR w KQkq - 0 1


### PR DESCRIPTION
Adds a `y` prefix to the Betza parser for **bent riders**: a piece that takes
one leg, may stop there, and otherwise rides on without limit 45 degrees off
that leg, away from where it started. Five pieces come out of it, all
declarable through `customPieceN`, none of which is expressible today:

| Betza | piece | move |
|---|---|---|
| `yF` | griffon | diagonal step, then an orthogonal ride out |
| `yW` | rhino | orthogonal step, then a diagonal ride out |
| `yvF` | ship | the griffon, keeping only the file-wise ride |
| `vyW` | snake | the rhino, stepping only along a file first |
| `yD` | osprey | two-square orthogonal leap, then a diagonal ride out |

Two commits on top of `6d9d0f5`, 361 insertions across 10 files:
`bf66fa7 add bent riders` and `c18ed4d bent riders : add osprey`.

Related: #962, where @HGMuller implemented a superset of this on the `pieces`
branch of his repository, and #966 / #967.

`PieceInfo` currently has only `steps`, `slider` and `hopper`, none of which
can encode a change of direction mid-move, so this is a data-model addition
rather than a parser tweak. What made it worth doing now: the crashes
@HGMuller reported in #962 turned out to be the #966 bug you fixed in #967, so
there is no known blocker left on top of master.

## How the attacks are computed

**No new magic table.** A griffon's relevant-occupancy mask spans two whole
files and two whole ranks — around 24 squares on 8x8 before edge trimming, and
worse on 12x10 — so a dedicated magic would be memory-hungry for a piece most
variants never use. The attacks are composed from the rook and bishop magics
instead.

The construction rests on one observation about `QueenDirections`, which this
patch adds in **rotational order**, so that stepping ±1 through the table is a
45 degree turn and the diagonals sit at the odd indices:

> Rotating by ±1 flips the index parity. So **both** continuations of an
> orthogonal leg are diagonal, and **both** continuations of a diagonal leg
> are orthogonal — never a mix.

That is what makes a single lookup enough. For each leg:

1. Step or leap to the corner square `t`. If it is off the board, wraps
   (`distance(s, t) != len`), or is occupied, this leg contributes nothing
   further — an occupied corner blocks the ride, which is the rule.
2. Take **one** attack lookup from `t`: `attacks_bb<ROOK>` when the leg index
   is odd (diagonal leg, orthogonal continuations), `attacks_bb<BISHOP>` when
   it is even. One probe covers both continuations at once, and it already
   applies the blocking rules along them, which are exactly a bent rider's.
3. Mask with `RayBB[(i+1)&7][t] | RayBB[(i+7)&7][t]` to keep only the two
   outgoing rays, discarding the two that point back toward the origin.

```cpp
Square t = Square(s + br.len[k] * QueenDirections[i]);
if (!is_ok(t) || distance(s, t) != br.len[k] || (occupied & t))
    continue;
Bitboard rays = 0;
if (br.cont[k] & 1) rays |= RayBB[(i + 1) & 7][t];
if (br.cont[k] & 2) rays |= RayBB[(i + 7) & 7][t];
b |= ((i & 1) ? attacks_bb<ROOK>(t, occupied) : attacks_bb<BISHOP>(t, occupied)) & rays;
```

The only new table is `RayBB[8][SQUARE_NB]`, the rays to the board edge in
each queen direction: **8 KB, or 16 KB with `LARGEBOARDS`**.

Cost per attack query: four legs, one rook or bishop lookup each. Since the
rook is split into H and V magics, a griffon costs 8 magic probes against 2
for a queen; a rhino or osprey rides diagonally and costs 4. Per-quadrant
magics — mask being one partial file plus one partial rank from the corner,
hence small — are the obvious follow-up if this ever shows up in a profile.

**The rider bit carries no shape.** One `RIDER_BENT` bit covers all five
pieces; the shape lives in `BentAttacks[COLOR_NB][PIECE_TYPE_NB]`, holding per
leg a direction index, a leg length and a two-bit continuation mask. Black is
the same table with each leg turned through 180 degrees, a half-turn in the
direction table, which leaves the mask unchanged. The bit is placed **after
every magic-backed rider** and stripped by a new `MAGIC_RIDERS` mask before
the loop in `rider_attacks_bb`, which indexes `magics[]` by bit position and
would otherwise run off the end.

The second commit only changes how the corner is reached: `s + len *
QueenDirections[i]`, with `distance()` catching a leg that ran off the side.
A leg longer than one square is a **leap** — nothing between is examined —
and the parity selector still holds, because what gets rotated is the
direction the leg points in, not its length.

## Why bent riders cannot use the existing fast paths

Reachability is symmetric, but **the path is not**. A griffon on a1 reaches b5
via b2-b3-b4; a griffon on b5 reaches a1 via a4-a3-a2. The blocking sets are
disjoint. Three consequences:

- `checkSquares[pt]`, computed from the king square, assumes reversibility.
- `BetweenBB`, built as the intersection of the two reciprocal attack sets,
  gives `{c2}` for a1/b5 instead of `{a2, a3, a4}`.
- `slider_blockers()` would compute pins along the wrong squares.

Putting `RIDER_BENT` in `NON_SLIDING_RIDERS` and `ASYMMETRICAL_RIDERS` is
enough, and nothing else was needed. This matches what @HGMuller reported in
#962: declaring the new rider types non-sliding and asymmetrical was what made
his king captures go away. `NON_SLIDING_RIDERS` makes `generate_all<EVASIONS>`
fall back to `target = ~pos.pieces(Us)` and makes `legal()` skip its
`between_bb` shortcut, leaving the full `attackers_to()` at the end of
`legal()` to cover pins; `ASYMMETRICAL_RIDERS` makes `slider_blockers()`,
`attackers_to()` and `gives_check()` recompute from each candidate square
rather than reversing.

`bent_path_bb()` supplies a **directed** `between_bb(s1, s2, pt)`, traced from
the piece towards the target. `checkSquares` stays the approximate forward
set, exactly as it already is for `HORSE`, which is also in
`ASYMMETRICAL_RIDERS`; it only feeds `QUIET_CHECKS`, so the cost is a little
search quality, not correctness.

One incidental fix: `psqt.cpp` reads only `slider` and `hopper` when deciding
`isSlider`, so a piece whose movement lives in `bent` was silently classified
as a non-slider. Each continuation now counts as three quarters of a slider
direction, which puts the griffon slightly below the queen — matching its
empty-board mobility of 21.4 squares against 22.75 — and values the
half-versions at about half the full piece.

## Testing

**No regression on standard chess.** `bench` gives 6180480 with and without
the patch. Perft from the start position to depth 6 = 119060324 and Kiwipete
to depth 5 = 193690690.

**Move generation** cross-checked against an independent path-walking
reference over 600 random 12x10 positions with friendly and enemy blockers,
spread across all four shapes of the first commit: 0 disagreements. On an
empty 8x8 board from d4 the five pieces give 24, 24, 12, 14 and 16 moves, each
verified by hand as well.

**Check detection.** Two positions, same pieces, the blocker moved from b3 to
a3, in a variant with `customPiece1 = g:yF`:

| FEN | expected | result |
|---|---|---|
| `7k/8/8/1g6/8/1P6/8/K7 w - - 0 1` | check, 2 legal moves | `Checkers: b5`, perft 1 = 2 |
| `7k/8/8/1g6/8/P7/8/K7 w - - 0 1` | no check, 4 legal moves | no checkers, perft 1 = 4 |

An implementation treating the griffon as symmetric gets both backwards.
Worth keeping as a regression test.

**The osprey leaps.** With a knight on e4 all 16 moves from d4 remain,
including d4f4 and the ride g5/h6; with the landing square f4 occupied, d4f4
stays as a capture but the ride beyond disappears.

**Stress.** 34,663 plies of random games on a `debug=yes` build in a 12x10
variant holding four bent riders at once, plus 17,721 more once the osprey was
added, plus `go depth 22` on K+G vs K endgames, which is where #962 crashed.
No assertion failures.

## Cost

Comparing like with like — both as user-defined variants, both at
`go movetime 6000` from the start position — a chess variant with a griffon in
place of the queen runs at 299 knps against 504 knps, so **about 40% slower**.
That is the asymmetrical and non-sliding paths plus the extra magic probes,
and it only affects variants that use the piece.

## Questions

1. **The first commit carries an unrelated change.** It also adds
   `enPassantTargetTypes`, a `PieceSet` letting a non-pawn leave en passant
   squares on any move of more than one square, which today only happens on a
   move its *initial* move set alone could make. I needed it for a piece that
   keeps a two-square step all game. Say the word and I will split it into its
   own PR; the two are independent.
2. **Notation.** `y` with a directional modifier before it restricting the
   first leg (`vyW`) and a single `v`/`h` straight after it restricting the
   ride (`yvF`). `yafsF` is accepted as an alias of `yF` so a piece written for
   @HGMuller's branch parses unchanged. Is that the spelling you want in the
   documented Betza subset, or should it track his branch more closely?
3. Would you rather upstream his `pieces` branch as a whole now that #967 has
   landed? It is broader — ski sliders, long-stride riders — and this PR
   should be dropped in its favour if so.
4. Is the ~40% acceptable, or would you want per-quadrant magics up front?

NNUE does not know the pieces, so variants using them run on classical eval.