### PR TITLE
Avoid eval trace crashes in positions ended by variant rules

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1674,6 +1674,9 @@ std::string Eval::trace(Position& pos) {
   if (pos.checkers())
       return "Final evaluation: none (in check)";
 
+  if (pos.is_immediate_game_end())
+      return "Final evaluation: none (variant end)";
+
   std::stringstream ss;
   ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
 


### PR DESCRIPTION
Calling `eval` on a Teeko position with a completed four-piece line still causes SIGFPE: `Eval::trace()` enters classical evaluation even though a variant rule has already ended the game. Return `Final evaluation: none (variant end)` before entering the evaluator, matching its existing precondition and handling of positions in check.

Reproducer (start the engine with `load variants.ini`):
```
setoption name Use NNUE value false
setoption name UCI_Variant value teeko
position startpos moves P@a1 P@a5 P@b1 P@c5 P@c1 P@e5 P@d1
eval
```

Related to #800. The original search crash was already fixed by #814; this addresses the remaining diagnostic-command path.

Validation: reproduced SIGFPE before the change; checked all four line directions, a square win, and a black win after it. Protocol tests, variants.ini validation, and bench passed in a debug build with all variants and large boards. The classical release bench signature remains 6180480. No test changes are included.
