### PR TITLE
Add configurable piece-specific capture targets

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -25,6 +25,18 @@ namespace Stockfish {
 
 namespace {
 
+  template<Color Us>
+  Bitboard capture_targets(const Position& pos, PieceType attacker) {
+
+    if (!pos.has_capture_target_types(attacker))
+        return pos.pieces(~Us);
+
+    Bitboard targets = 0;
+    for (PieceSet ps = pos.capture_target_types(attacker); ps;)
+        targets |= pos.pieces(~Us, pop_lsb(ps));
+    return targets;
+  }
+
   template<MoveType T>
   ExtMove* make_move_and_gating(const Position& pos, ExtMove* moveList, Color us, Square from, Square to, PieceType pt = NO_PIECE_TYPE) {
 
@@ -149,7 +161,7 @@ namespace {
 
     const Bitboard pawns      = pos.pieces(Us, PAWN);
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
-    const Bitboard capturable = pos.board_bb(Us, PAWN) &  pos.pieces(Them);
+    const Bitboard capturable = pos.board_bb(Us, PAWN) & capture_targets<Us>(pos, PAWN);
 
     target = Type == EVASIONS ? target : AllSquares;
 
@@ -264,7 +276,7 @@ namespace {
             moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - UpLeft, to);
         }
 
-        for (Bitboard epSquares = pos.ep_squares() & ~pos.pieces(); epSquares; )
+        for (Bitboard epSquares = pos.can_capture(PAWN, PAWN) ? pos.ep_squares() & ~pos.pieces() : Bitboard(0); epSquares; )
         {
             Square epSquare = pop_lsb(epSquares);
 
@@ -299,7 +311,7 @@ namespace {
 
         Bitboard attacks = pos.attacks_from(Us, Pt, from);
         Bitboard quiets = pos.moves_from(Us, Pt, from);
-        Bitboard b = (  (attacks & pos.pieces())
+        Bitboard b = (  (attacks & capture_targets<Us>(pos, Pt))
                        | (quiets & ~pos.pieces()));
         Bitboard b1 = b & target;
         Bitboard promotion_zone = pos.promotion_zone(Us);
@@ -455,7 +467,7 @@ namespace {
     // King moves
     if (pos.count<KING>(Us) && (!Checks || pos.blockers_for_king(~Us) & ksq))
     {
-        Bitboard b = (  (pos.attacks_from(Us, KING, ksq) & pos.pieces())
+        Bitboard b = (  (pos.attacks_from(Us, KING, ksq) & capture_targets<Us>(pos, KING))
                       | (pos.moves_from(Us, KING, ksq) & ~pos.pieces())) & (Type == EVASIONS ? ~pos.pieces(Us) : target);
         while (b)
             moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, ksq, pop_lsb(b));

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -319,7 +319,7 @@ namespace {
         Bitboard b2 = promPt && (!pos.promotion_limit(promPt) || pos.promotion_limit(promPt) > pos.count(Us, promPt)) ? b1 : Bitboard(0);
         Bitboard b3 = pos.piece_demotion() && pos.is_promoted(from) ? b1 : Bitboard(0);
         Bitboard pawnPromotions = (pos.promotion_pawn_types(Us) & Pt) ? (b & (Type == EVASIONS ? target : ~pos.pieces(Us)) & promotion_zone) : Bitboard(0);
-        Bitboard epSquares = (pos.en_passant_types(Us) & Pt) ? (attacks & ~quiets & pos.ep_squares() & ~pos.pieces()) : Bitboard(0);
+        Bitboard epSquares = (pos.en_passant_types(Us) & Pt) && pos.can_capture(Pt, PAWN) ? (attacks & ~quiets & pos.ep_squares() & ~pos.pieces()) : Bitboard(0);
 
         // target squares considering pawn promotions
         if (pawnPromotions && pos.mandatory_pawn_promotion())

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -238,6 +238,47 @@ template <bool Current, class T> bool VariantParser<DoCheck>::parse_attribute(co
 }
 
 template <bool DoCheck>
+template <bool Current> bool VariantParser<DoCheck>::parse_attribute(const std::string& key, PieceSet (&targetTypes)[PIECE_TYPE_NB], bool (&defined)[PIECE_TYPE_NB], std::string pieceToChar) {
+    const auto& it = config.find(key);
+    if (it != config.end())
+    {
+        std::string mapping;
+        std::stringstream ss(it->second);
+        while (ss >> mapping)
+        {
+            size_t attacker = mapping.size() > 2 && mapping[1] == ':' ? pieceToChar.find(toupper(mapping[0])) : std::string::npos;
+            if (attacker == std::string::npos)
+            {
+                if (DoCheck)
+                    std::cerr << key << " - Invalid mapping: " << mapping << std::endl;
+                continue;
+            }
+
+            defined[attacker] = true;
+            targetTypes[attacker] = NO_PIECE_SET;
+            for (size_t i = 2; i < mapping.size() && mapping[i] != '-'; ++i)
+            {
+                if (mapping[i] == '*')
+                {
+                    targetTypes[attacker] = ~NO_PIECE_SET;
+                    break;
+                }
+                size_t targetPiece = pieceToChar.find(toupper(mapping[i]));
+                if (targetPiece == std::string::npos)
+                {
+                    if (DoCheck)
+                        std::cerr << key << " - Invalid target piece type: " << mapping[i] << std::endl;
+                    continue;
+                }
+                targetTypes[attacker] |= PieceType(targetPiece);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+template <bool DoCheck>
 Variant* VariantParser<DoCheck>::parse() {
     Variant* v = new Variant();
     v->reset_pieces();
@@ -419,6 +460,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("blastOnCapture", v->blastOnCapture);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v->pieceToChar);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v->pieceToChar);
+    parse_attribute("captureTargetTypes", v->captureTargetTypes, v->captureTargetTypesDefined, v->pieceToChar);
     parse_attribute("petrifyOnCaptureTypes", v->petrifyOnCaptureTypes, v->pieceToChar);
     parse_attribute("petrifyBlastPieces", v->petrifyBlastPieces);
     parse_attribute("doubleStep", v->doubleStep);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -246,6 +246,8 @@ template <bool Current> bool VariantParser<DoCheck>::parse_attribute(const std::
         std::stringstream ss(it->second);
         while (ss >> mapping)
         {
+            if (!mapping.empty() && (mapping[0] == '#' || mapping[0] == ';'))
+                break;
             size_t attacker = mapping.size() > 2 && mapping[1] == ':' ? pieceToChar.find(toupper(mapping[0])) : std::string::npos;
             if (attacker == std::string::npos)
             {

--- a/src/parser.h
+++ b/src/parser.h
@@ -52,6 +52,7 @@ private:
     Config config;
     template <bool Current = true, class T> bool parse_attribute(const std::string& key, T& target);
     template <bool Current = true, class T> bool parse_attribute(const std::string& key, T& target, std::string pieceToChar);
+    template <bool Current = true> bool parse_attribute(const std::string& key, PieceSet (&targetTypes)[PIECE_TYPE_NB], bool (&defined)[PIECE_TYPE_NB], std::string pieceToChar);
 };
 
 } // namespace Stockfish

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1059,6 +1059,10 @@ bool Position::legal(Move m) const {
   assert(!count<KING>(us) || piece_on(square<KING>(us)) == make_piece(us, KING));
   assert(board_bb() & to);
 
+  // Illegal captures
+  if (capture(m) && !can_capture(type_of(moved_piece(m)), type_of(piece_on(type_of(m) == EN_PASSANT ? capture_square(to) : to))))
+      return false;
+
   // Illegal checks
   if ((!checking_permitted() || (sittuyin_promotion() && type_of(m) == PROMOTION) || (!drop_checks() && type_of(m) == DROP)) && gives_check(m))
       return false;
@@ -1370,6 +1374,10 @@ bool Position::pseudo_legal(const Move m) const {
 
   // The destination square cannot be occupied by a friendly piece
   if (pieces(us) & to)
+      return false;
+
+  // The moving piece may be restricted to particular capture target types.
+  if (capture(m) && !can_capture(type_of(pc), type_of(piece_on(type_of(m) == EN_PASSANT ? capture_square(to) : to))))
       return false;
 
   // Handle the special case of a pawn move

--- a/src/position.h
+++ b/src/position.h
@@ -284,6 +284,9 @@ public:
   bool pseudo_legal(const Move m) const;
   bool virtual_drop(Move m) const;
   bool capture(Move m) const;
+  bool can_capture(PieceType attacker, PieceType target) const;
+  bool has_capture_target_types(PieceType attacker) const;
+  PieceSet capture_target_types(PieceType attacker) const;
   bool capture_or_promotion(Move m) const;
   Square capture_square(Square to) const;
   bool gives_check(Move m) const;
@@ -1443,6 +1446,21 @@ inline bool Position::capture(Move m) const {
   assert(is_ok(m));
   // Castling is encoded as "king captures rook"
   return (!empty(to_sq(m)) && type_of(m) != CASTLING && from_sq(m) != to_sq(m)) || type_of(m) == EN_PASSANT;
+}
+
+inline bool Position::can_capture(PieceType attacker, PieceType target) const {
+  assert(var != nullptr);
+  return !var->captureTargetTypesDefined[attacker] || (var->captureTargetTypes[attacker] & piece_set(target));
+}
+
+inline bool Position::has_capture_target_types(PieceType attacker) const {
+  assert(var != nullptr);
+  return var->captureTargetTypesDefined[attacker];
+}
+
+inline PieceSet Position::capture_target_types(PieceType attacker) const {
+  assert(var != nullptr);
+  return var->captureTargetTypes[attacker];
 }
 
 inline Square Position::capture_square(Square to) const {

--- a/src/variant.h
+++ b/src/variant.h
@@ -66,6 +66,8 @@ struct Variant {
   bool blastOnCapture = false;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
+  PieceSet captureTargetTypes[PIECE_TYPE_NB] = {};
+  bool captureTargetTypesDefined[PIECE_TYPE_NB] = {};
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;
   bool petrifyBlastPieces = false;
   bool doubleStep = true;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -185,6 +185,7 @@
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
+# captureTargetTypes: allowed capture targets by attacker, e.g., r:n b:pq means rooks capture only knights and bishops capture only pawns and queens; use - for no targets and * for all targets [PieceType:PieceSet] (default: unrestricted)
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)


### PR DESCRIPTION
Adds a `captureTargetTypes` variant option to restrict which piece types may be captured by each attacker. This allows for games with intransitivity, such as rock paper scissors-style games. [_Intransitive_ ](https://meaf.us/rps2/)is a new such game, [attached is a variants.ini](https://github.com/user-attachments/files/31931977/intransitive-variants.txt) file for the game.

#### Example
```ini
captureTargetTypes = r:n b:pq # This allows rooks to capture only knights and bishops to capture only pawns and queens.
```

#### Details
- Adds per-piece allowed capture target lists
- Filters pseudo-legal capture generation for pawns, kings, standard pieces, and custom pieces
- Applies the restriction in `legal()` and `pseudo_legal()` as well, including en passant
- Supports:
    - `r:-` rook captures nothing
    - `r:*` rook may capture every piece type
- Documents the option in `variants.ini`
- Leaves existing variants unchanged unless they opt into captureTargetTypes

Closes #1005, Closes #1037